### PR TITLE
Force use of nightly with rust-toolchain.toml

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -138,13 +138,9 @@ jobs:
         ninja -C build install
       if: matrix.qemu != '' && matrix.os == 'ubuntu-latest'
 
-    - name: Install rust-src
-      run: |
-        rustup component add rust-src --toolchain nightly-2023-06-27-x86_64-unknown-linux-gnu
-
     - name: test origin-as-just-a-library in non-mustang mode
       working-directory: test-crates/origin-as-just-a-library
       run: |
-        cargo +nightly-2023-06-27 run --target=${{ matrix.host_target }}
+        cargo run --target=${{ matrix.host_target }}
       env:
         RUST_BACKTRACE: 1

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,2 @@
+[toolchain]
+channel = "nightly"

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,2 +1,3 @@
 [toolchain]
 channel = "nightly"
+components = ["rustfmt"]

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "nightly"
-components = ["rustfmt"]
+channel = "nightly-2023-06-27"
+components = ["rustc", "cargo", "rust-std", "rust-src", "rustfmt"]


### PR DESCRIPTION
This pr adds a rust-toolchain.toml file that ensures the project is compiled using rust nightly.