### PR TITLE
Update dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ edition = "2021"
 linux-raw-sys = { version = "0.4.3", default-features = false, features = ["general", "no_std"] }
 rustix = { version = "0.38.1", default-features = false, features = ["mm", "thread", "time", "runtime", "param", "process"] }
 bitflags = "2.4.0"
-memoffset = { version = "0.8.0", optional = true }
+memoffset = { version = "0.9.0", optional = true }
 log = { version = "0.4.14", default-features = false, optional = true }
 lock_api = { version = "0.4.7", features = ["nightly"] }
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ edition = "2021"
 [dependencies]
 linux-raw-sys = { version = "0.4.3", default-features = false, features = ["general", "no_std"] }
 rustix = { version = "0.38.1", default-features = false, features = ["mm", "thread", "time", "runtime", "param", "process"] }
-bitflags = "1.3.0"
+bitflags = "2.4.0"
 memoffset = { version = "0.8.0", optional = true }
 log = { version = "0.4.14", default-features = false, optional = true }
 lock_api = { version = "0.4.7", features = ["nightly"] }


### PR DESCRIPTION
This pr updates bitflags and memoffset crates to their latest version.

The bitflags crate is updated to version 2, while this release does contain breaking changes, it is only used internally and not exposed to the public api.

The memoffset crate does not include any breaking change but only adds a new feature flag disabled by default.