### PR TITLE
Update toolchain to latest nightly

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "nightly-2023-06-27"
+channel = "nightly-2023-08-25"
 components = ["rustc", "cargo", "rust-std", "rust-src", "rustfmt"]


### PR DESCRIPTION
Simply updates to a more recent nightly, it isn't strictly required but rust 1.72.0 has already been released so technically the old nightly was outdated. It's better to wait for #4 before merging this otherwise the ci and the toolchain would be out of sync.