### PR TITLE
Factor the origin-program feature to allow using it without a start.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -62,17 +62,22 @@ origin-all = [
     "origin-signals",
 ]
 
-origin-start = []
-external-start = []
-
 # Use origin's implementation of program startup and shutdown.
-origin-program = ["rustix/use-explicitly-provided-auxv", "rustix/runtime"]
+origin-program = []
 
 # Use origin's implementation of thread startup and shutdown.
 origin-threads = ["memoffset", "rustix/runtime", "origin-program"]
 
 # Use origin's implementation of signal handle registrtion.
 origin-signals = ["rustix/runtime"]
+
+# Use origin's `_start` definition.
+origin-start = ["rustix/use-explicitly-provided-auxv", "rustix/runtime"]
+
+# Don't use origin's `_start` definition, but export a `start` function which
+# is meant to be run very early in program startup and passed a pointer to
+# the initial stack. Don't enable this when enabling "origin-start".
+external-start = ["rustix/use-explicitly-provided-auxv", "rustix/runtime"]
 
 # Disable logging.
 max_level_off = ["log/max_level_off"]

--- a/src/arch-x86_64.rs
+++ b/src/arch-x86_64.rs
@@ -51,7 +51,7 @@ pub(super) unsafe fn clone(
 }
 
 /// Write a value to the platform thread-pointer register.
-#[cfg(feature = "origin-threads")]
+#[cfg(any(feature = "origin-start", feature = "external-start"))]
 #[inline]
 pub(super) unsafe fn set_thread_pointer(ptr: *mut c_void) {
     rustix::runtime::set_fs(ptr);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -124,10 +124,6 @@ pub unsafe fn start(mem: *mut usize) -> ! {
     program::entry(mem)
 }
 
-#[cfg(feature = "origin-program")]
-#[cfg(not(any(feature = "origin-start", feature = "external-start")))]
-compile_error!("origin-program depends on either origin-start or external-start");
-
 /// An ABI-conforming `__dso_handle`.
 #[cfg(feature = "origin-program")]
 #[cfg(feature = "origin-start")]


### PR DESCRIPTION
Factor the origin-program feature better so that it can be used without either origin-start or external-start.