### PR TITLE
Add more types and constants to the signals API.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -32,7 +32,7 @@ extern crate unwinding;
 mod arch;
 
 pub use program::{at_exit, exit, exit_immediately};
-pub use signals::{sigaction, Sigaction};
+pub use signals::{sig_ign, sigaction, Sigaction, Sigflags, Sighandler, Signal, SA_RESTART};
 #[cfg(feature = "set_thread_id")]
 pub use threads::set_current_thread_id_after_a_fork;
 #[cfg(feature = "origin-threads")]

--- a/src/signals.rs
+++ b/src/signals.rs
@@ -1,5 +1,4 @@
 use rustix::io;
-use rustix::process::Signal;
 #[cfg(not(target_arch = "riscv64"))]
 use {
     crate::arch,
@@ -8,7 +7,16 @@ use {
 };
 
 /// A signal action record for use with [`sigaction`].
-pub type Sigaction = linux_raw_sys::general::kernel_sigaction;
+pub use rustix::runtime::Sigaction;
+
+/// A signal identifiier for use with [`sigaction`].
+pub use rustix::process::Signal;
+
+/// A signal handler function for use with [`Sigaction`].
+pub use linux_raw_sys::general::__kernel_sighandler_t as Sighandler;
+
+/// A flags type for use with [`Sigaction`].
+pub use linux_raw_sys::ctypes::c_ulong as Sigflags;
 
 /// Register a signal handler.
 ///
@@ -32,3 +40,12 @@ pub unsafe fn sigaction(sig: Signal, action: Option<Sigaction>) -> io::Result<Si
 
     rustix::runtime::sigaction(sig, action)
 }
+
+/// Return a special "ignore" signal handler for ignoring signals.
+#[doc(alias = "SIG_IGN")]
+pub fn sig_ign() -> Sighandler {
+    linux_raw_sys::signal_macros::sig_ign()
+}
+
+/// `SA_RESTART`
+pub const SA_RESTART: Sigflags = linux_raw_sys::general::SA_RESTART as _;

--- a/src/signals_via_libc.rs
+++ b/src/signals_via_libc.rs
@@ -1,10 +1,18 @@
 use core::mem::MaybeUninit;
 use core::ptr::null;
 use rustix::io;
-use rustix::process::Signal;
 
 /// A signal action record for use with [`sigaction`].
 pub type Sigaction = libc::sigaction;
+
+/// A signal identifiier for use with [`sigaction`].
+pub use rustix::process::Signal;
+
+/// A signal handler function for use with [`Sigaction`].
+pub use libc::sighandler_t as Sighandler;
+
+/// A flags type for use with [`Sigaction`].
+pub use linux_raw_sys::ctypes::c_int as Sigflags;
 
 /// Register a signal handler.
 ///
@@ -26,3 +34,12 @@ pub unsafe fn sigaction(sig: Signal, action: Option<Sigaction>) -> io::Result<Si
         Err(rustix::io::Errno::from_raw_os_error(libc::EINVAL))
     }
 }
+
+/// Return a special "ignore" signal handler for ignoring signals.
+#[doc(alias = "SIG_IGN")]
+pub fn sig_ign() -> Sighandler {
+    libc::SIG_IGN
+}
+
+/// `SA_RESTART`
+pub const SA_RESTART: Sigflags = libc::SA_RESTART;


### PR DESCRIPTION
Expose `Sigaction`, `Signal`, `Sigflags`, and `sig_ign` in the signals APIs.