### PR TITLE
Put allocation behind a feature flag

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,9 @@ include = ["src", "Cargo.toml", "COPYRIGHT", "LICENSE*", "/*.md"]
 
 [dependencies]
 linux-raw-sys = { version = "0.4.3", default-features = false, features = ["general", "no_std"] }
-rustix = { version = "0.38.9", default-features = false, features = ["mm", "thread", "time", "param", "process"] }
+# rustix = { version = "0.38.9", default-features = false, features = ["mm", "thread", "time", "param", "process"] }
+# Only needed until a new version of rustix is released
+rustix = { git = "https://github.com/bytecodealliance/rustix.git", branch = "main", default-features = false, features = ["mm", "thread", "time", "param", "process"] }
 bitflags = "2.4.0"
 memoffset = { version = "0.9.0", optional = true }
 log = { version = "0.4.14", default-features = false, optional = true }
@@ -45,11 +47,12 @@ similar-asserts = "1.1.0"
 
 [features]
 default = ["std", "log", "libc"]
-std = ["rustix/std"]
+std = ["rustix/std", "alloc"]
+alloc = ["rustix/alloc"]
 set_thread_id = []
 rustc-dep-of-std = [
-    "core",
-    "alloc",
+    "dep:core",
+    "dep:alloc",
     "linux-raw-sys/rustc-dep-of-std",
     "bitflags/rustc-dep-of-std",
     "libc/rustc-dep-of-std",

--- a/src/arch-aarch64.rs
+++ b/src/arch-aarch64.rs
@@ -2,12 +2,14 @@ use core::arch::asm;
 use linux_raw_sys::general::__NR_rt_sigreturn;
 #[cfg(feature = "origin-threads")]
 use {
-    alloc::boxed::Box,
     core::any::Any,
     core::ffi::c_void,
     linux_raw_sys::general::{__NR_clone, __NR_exit, __NR_munmap},
     rustix::process::RawPid,
 };
+
+#[cfg(all(feature = "alloc", not(feature = "rustc-dep-of-std")))]
+use alloc::boxed::Box;
 
 /// A wrapper around the Linux `clone` system call.
 #[cfg(feature = "origin-threads")]

--- a/src/arch-arm.rs
+++ b/src/arch-arm.rs
@@ -2,12 +2,14 @@ use core::arch::asm;
 use linux_raw_sys::general::{__NR_rt_sigreturn, __NR_sigreturn};
 #[cfg(feature = "origin-threads")]
 use {
-    alloc::boxed::Box,
     core::any::Any,
     core::ffi::c_void,
     linux_raw_sys::general::{__NR_clone, __NR_exit, __NR_munmap},
     rustix::process::RawPid,
 };
+
+#[cfg(all(feature = "alloc", not(feature = "rustc-dep-of-std")))]
+use alloc::boxed::Box;
 
 /// A wrapper around the Linux `clone` system call.
 #[cfg(feature = "origin-threads")]

--- a/src/arch-riscv64.rs
+++ b/src/arch-riscv64.rs
@@ -1,12 +1,14 @@
 #[cfg(feature = "origin-threads")]
 use {
-    alloc::boxed::Box,
     core::any::Any,
     core::arch::asm,
     core::ffi::c_void,
     linux_raw_sys::general::{__NR_clone, __NR_exit, __NR_munmap},
     rustix::process::RawPid,
 };
+
+#[cfg(all(feature = "alloc", not(feature = "rustc-dep-of-std")))]
+use alloc::boxed::Box;
 
 /// A wrapper around the Linux `clone` system call.
 #[cfg(feature = "origin-threads")]

--- a/src/arch-x86_64.rs
+++ b/src/arch-x86_64.rs
@@ -2,15 +2,17 @@ use core::arch::asm;
 use linux_raw_sys::general::__NR_rt_sigreturn;
 #[cfg(feature = "origin-threads")]
 use {
-    alloc::boxed::Box,
     core::any::Any,
     core::ffi::c_void,
     linux_raw_sys::general::{__NR_clone, __NR_exit, __NR_munmap},
     rustix::process::RawPid,
 };
 
+#[cfg(all(feature = "origin-threads", feature = "alloc"))]
+use alloc::boxed::Box;
+
 /// A wrapper around the Linux `clone` system call.
-#[cfg(feature = "origin-threads")]
+#[cfg(all(feature = "origin-threads", feature = "alloc"))]
 #[inline]
 pub(super) unsafe fn clone(
     flags: u32,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,7 +9,7 @@
 #![deny(lossy_provenance_casts)]
 #![no_std]
 
-#[cfg(not(feature = "rustc-dep-of-std"))]
+#[cfg(all(feature = "alloc", not(feature = "rustc-dep-of-std")))]
 extern crate alloc;
 
 mod program;


### PR DESCRIPTION
This pr is an attempt at putting origin dependence on alloc behind a feature flag. In it's current state it's very much broken but that is somewhat intentional as I wanted open a draft pr to allow for discussions on possible implementation. The main issue currently is the usage of alloc items in the `initialize_main_thread` function. This function is called by `entry` which itself is called by `_start` making it required to start the program.
To make this work we probably need to do one of the following

- Change the way the main thread initialization work to not use alloc (not sure if this is desired or even possible)
- Create an alternative implementation of main thread initialization that does not require alloc
- Possibly rethink the entire way the startup code works (this seems like a very unlikely option however)
- ???

On a side-note, this currently depends on https://github.com/bytecodealliance/rustix/pull/800 which has not been published yet so the rustix dependency is temporarily pointing to the git repo
