### PR TITLE
Put allocation behind a cargo feature, and make the API more modular.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ include = ["src", "Cargo.toml", "COPYRIGHT", "LICENSE*", "/*.md"]
 
 [dependencies]
 linux-raw-sys = { version = "0.4.3", default-features = false, features = ["general", "no_std"] }
-rustix = { version = "0.38.9", default-features = false, features = ["mm", "thread", "time", "param", "process"] }
+rustix = { version = "0.38.9", default-features = false }
 bitflags = "2.4.0"
 memoffset = { version = "0.9.0", optional = true }
 log = { version = "0.4.14", default-features = false, optional = true }
@@ -44,44 +44,50 @@ features = [ "unwinder" ]
 similar-asserts = "1.1.0"
 
 [features]
-default = ["std", "log", "libc"]
+default = ["std", "log", "libc", "thread"]
 std = ["rustix/std"]
 set_thread_id = []
 rustc-dep-of-std = [
-    "core",
-    "alloc",
+    "dep:core",
+    "dep:alloc",
     "linux-raw-sys/rustc-dep-of-std",
     "bitflags/rustc-dep-of-std",
     "libc/rustc-dep-of-std",
-]
-
-# Use origin's implementations for everything.
-origin-all = [
-    "origin-program",
-    "origin-threads",
-    "origin-signals",
 ]
 
 # Use origin's implementation of program startup and shutdown.
 origin-program = []
 
 # Use origin's implementation of thread startup and shutdown.
-origin-threads = ["memoffset", "rustix/runtime", "origin-program"]
+origin-thread = ["memoffset", "rustix/runtime", "origin-program", "thread"]
 
 # Use origin's implementation of signal handle registrtion.
-origin-signals = ["rustix/runtime"]
+origin-signal = ["rustix/runtime", "signal"]
 
 # Use origin's `_start` definition.
-origin-start = ["rustix/use-explicitly-provided-auxv", "rustix/runtime"]
+origin-start = ["rustix/use-explicitly-provided-auxv", "rustix/param", "rustix/runtime"]
 
 # Don't use origin's `_start` definition, but export a `start` function which
 # is meant to be run very early in program startup and passed a pointer to
 # the initial stack. Don't enable this when enabling "origin-start".
-external-start = ["rustix/use-explicitly-provided-auxv", "rustix/runtime"]
+external-start = ["rustix/use-explicitly-provided-auxv", "rustix/param", "rustix/runtime"]
 
 # Disable logging.
 max_level_off = ["log/max_level_off"]
 
+# Enable features which depend on the Rust global allocator, such as functions
+# that return owned strings or `Vec`s.
+alloc = ["rustix/alloc"]
+
+# Enable support for threads.
+thread = ["alloc", "rustix/thread", "rustix/mm", "rustix/param", "rustix/process", "rustix/runtime"]
+
+# Enable support for signal handlers.
+signal = ["rustix/runtime"]
+
 [package.metadata.docs.rs]
-features = []
+features = ["origin-program", "origin-thread", "origin-signal", "origin-start"]
 rustdoc-args = ["--cfg", "doc_cfg"]
+
+[patch.crates-io]
+rustix = { git = "https://github.com/bytecodealliance/rustix", rev = "397155aa086fcdddb85319a4ae73652a27a0ab44" }

--- a/README.md
+++ b/README.md
@@ -49,6 +49,10 @@ Origin can also be used on its own, in several different configurations:
    prevents those flags from being passed to build scripts. origin handles
    program and thread startup and shutdown and no part of libc is used.
 
+ - The [origin-start-no-alloc example] is like origin-start, but disables the
+   "alloc" and "thread" features, so that it doesn't need to pull in a global
+   allocator.
+
 [basic example]: https://github.com/sunfishcode/origin/blob/main/test-crates/basic/README.md
 [no-std example]: https://github.com/sunfishcode/origin/blob/main/test-crates/no-std/README.md
 [external-start example]: https://github.com/sunfishcode/origin/blob/main/test-crates/external-start/README.md

--- a/src/arch-x86_64.rs
+++ b/src/arch-x86_64.rs
@@ -1,16 +1,19 @@
+#[cfg(any(feature = "origin-thread", feature = "origin-signal"))]
 use core::arch::asm;
+#[cfg(feature = "thread")]
+use core::ffi::c_void;
+#[cfg(feature = "origin-signal")]
 use linux_raw_sys::general::__NR_rt_sigreturn;
-#[cfg(feature = "origin-threads")]
+#[cfg(feature = "origin-thread")]
 use {
     alloc::boxed::Box,
     core::any::Any,
-    core::ffi::c_void,
     linux_raw_sys::general::{__NR_clone, __NR_exit, __NR_munmap},
-    rustix::process::RawPid,
+    rustix::thread::RawPid,
 };
 
 /// A wrapper around the Linux `clone` system call.
-#[cfg(feature = "origin-threads")]
+#[cfg(feature = "origin-thread")]
 #[inline]
 pub(super) unsafe fn clone(
     flags: u32,
@@ -35,7 +38,7 @@ pub(super) unsafe fn clone(
         // Parent thread.
         "0:",
 
-        entry = sym super::threads::entry,
+        entry = sym super::thread::entry,
         inlateout("rax") __NR_clone as isize => r0,
         in("rdi") flags,
         in("rsi") child_stack,
@@ -51,7 +54,10 @@ pub(super) unsafe fn clone(
 }
 
 /// Write a value to the platform thread-pointer register.
-#[cfg(any(feature = "origin-start", feature = "external-start"))]
+#[cfg(all(
+    feature = "origin-thread",
+    any(feature = "origin-start", feature = "external-start")
+))]
 #[inline]
 pub(super) unsafe fn set_thread_pointer(ptr: *mut c_void) {
     rustix::runtime::set_fs(ptr);
@@ -60,7 +66,10 @@ pub(super) unsafe fn set_thread_pointer(ptr: *mut c_void) {
 }
 
 /// Read the value of the platform thread-pointer register.
-#[cfg(feature = "origin-threads")]
+#[cfg(all(
+    feature = "origin-thread",
+    any(feature = "origin-start", feature = "external-start")
+))]
 #[inline]
 pub(super) fn get_thread_pointer() -> *mut c_void {
     let ptr;
@@ -71,12 +80,12 @@ pub(super) fn get_thread_pointer() -> *mut c_void {
 }
 
 /// TLS data ends at the location pointed to by the thread pointer.
-#[cfg(feature = "origin-threads")]
+#[cfg(feature = "origin-thread")]
 pub(super) const TLS_OFFSET: usize = 0;
 
 /// `munmap` the current thread, then carefully exit the thread without
 /// touching the deallocated stack.
-#[cfg(feature = "origin-threads")]
+#[cfg(feature = "origin-thread")]
 #[inline]
 pub(super) unsafe fn munmap_and_exit_thread(map_addr: *mut c_void, map_len: usize) -> ! {
     asm!(
@@ -95,6 +104,7 @@ pub(super) unsafe fn munmap_and_exit_thread(map_addr: *mut c_void, map_len: usiz
 
 /// Invoke the `__NR_rt_sigreturn` system call to return control from a signal
 /// handler.
+#[cfg(feature = "origin-signal")]
 #[naked]
 pub(super) unsafe extern "C" fn return_from_signal_handler() {
     asm!(
@@ -108,4 +118,5 @@ pub(super) unsafe extern "C" fn return_from_signal_handler() {
 
 /// Invoke the appropriate system call to return control from a signal
 /// handler that does not use `SA_SIGINFO`.
+#[cfg(feature = "origin-signal")]
 pub(super) use return_from_signal_handler as return_from_signal_handler_noinfo;

--- a/src/signal.rs
+++ b/src/signal.rs
@@ -1,3 +1,5 @@
+//! Signal handlers.
+
 use rustix::io;
 #[cfg(not(target_arch = "riscv64"))]
 use {crate::arch, linux_raw_sys::ctypes::c_ulong, linux_raw_sys::general::SA_RESTORER};
@@ -6,7 +8,7 @@ use {crate::arch, linux_raw_sys::ctypes::c_ulong, linux_raw_sys::general::SA_RES
 pub use rustix::runtime::Sigaction;
 
 /// A signal identifier for use with [`sigaction`].
-pub use rustix::process::Signal;
+pub use rustix::runtime::Signal;
 
 /// A signal handler function for use with [`Sigaction`].
 pub use linux_raw_sys::general::__kernel_sighandler_t as Sighandler;

--- a/src/signal_via_libc.rs
+++ b/src/signal_via_libc.rs
@@ -1,3 +1,5 @@
+//! Signal handlers.
+
 use core::mem::MaybeUninit;
 use core::ptr::null;
 use rustix::io;
@@ -6,7 +8,7 @@ use rustix::io;
 pub type Sigaction = libc::sigaction;
 
 /// A signal identifier for use with [`sigaction`].
-pub use rustix::process::Signal;
+pub use rustix::runtime::Signal;
 
 /// A signal handler function for use with [`Sigaction`].
 pub use libc::sighandler_t as Sighandler;

--- a/src/thread_via_libpthread.rs
+++ b/src/thread_via_libpthread.rs
@@ -1,7 +1,4 @@
-//! Threads runtime implemented using the native libpthread.
-//!
-//! This implementation uses libc to create and manage threads. See threads.rs
-//! for the Rust implementation.
+//! Thread startup and shutdown.
 
 use alloc::boxed::Box;
 use core::any::Any;
@@ -9,8 +6,7 @@ use core::ffi::c_void;
 use core::ptr::{from_exposed_addr_mut, null_mut, NonNull};
 use rustix::io;
 
-// FIXME: When bytecodealliance/rustix#796 lands, switch to rustix::thread.
-pub use rustix::process::Pid as ThreadId;
+pub use rustix::thread::Pid as ThreadId;
 
 // Symbols defined in libc but not declared in the libc crate.
 extern "C" {

--- a/test-crates/basic/Cargo.toml
+++ b/test-crates/basic/Cargo.toml
@@ -10,3 +10,6 @@ origin = { path = "../.." }
 
 # This is just an example crate, and not part of the origin workspace.
 [workspace]
+
+[patch.crates-io]
+rustix = { git = "https://github.com/bytecodealliance/rustix", rev = "397155aa086fcdddb85319a4ae73652a27a0ab44" }

--- a/test-crates/basic/src/main.rs
+++ b/test-crates/basic/src/main.rs
@@ -1,4 +1,5 @@
-use origin::*;
+use origin::thread::*;
+use origin::program::*;
 
 fn main() {
     eprintln!("Hello from main thread");

--- a/test-crates/external-start/Cargo.toml
+++ b/test-crates/external-start/Cargo.toml
@@ -6,9 +6,8 @@ publish = false
 
 [dependencies]
 # Origin can be depended on just like any other crate. For no_std, disable
-# the default features. And enable "origin-all" to enable the origin implementations.
-origin = { path = "../..", default-features = false, features = ["origin-all", "external-start"] }
-rustix = { version = "0.38.9", default-features = false }
+# the default features, and the desired features.
+origin = { path = "../..", default-features = false, features = ["origin-program", "origin-thread", "external-start"] }
 
 # Ensure that libc gets linked.
 libc = { version = "0.2", default-features = false }
@@ -20,3 +19,6 @@ compiler_builtins = { version = "0.1.101", features = ["mem"] }
 
 # This is just an example crate, and not part of the origin workspace.
 [workspace]
+
+[patch.crates-io]
+rustix = { git = "https://github.com/bytecodealliance/rustix", rev = "397155aa086fcdddb85319a4ae73652a27a0ab44" }

--- a/test-crates/external-start/src/main.rs
+++ b/test-crates/external-start/src/main.rs
@@ -13,7 +13,8 @@ extern crate libc;
 use alloc::boxed::Box;
 use atomic_dbg::{dbg, eprintln};
 use core::sync::atomic::{AtomicBool, Ordering};
-use origin::*;
+use origin::thread::*;
+use origin::program::*;
 
 #[panic_handler]
 fn panic(panic: &core::panic::PanicInfo<'_>) -> ! {

--- a/test-crates/no-std/Cargo.toml
+++ b/test-crates/no-std/Cargo.toml
@@ -7,7 +7,7 @@ publish = false
 [dependencies]
 # Origin can be depended on just like any other crate. For no_std, disable
 # the default features. And enable "libc" to enable the libc implementations.
-origin = { path = "../..", default-features = false, features = ["libc"] }
+origin = { path = "../..", default-features = false, features = ["libc", "thread"] }
 
 # Crates to help writing no_std code.
 atomic-dbg = { version = "0.1.7", default-features = false }
@@ -15,3 +15,6 @@ rustix-dlmalloc = { version = "0.1.0", features = ["global"] }
 
 # This is just an example crate, and not part of the origin workspace.
 [workspace]
+
+[patch.crates-io]
+rustix = { git = "https://github.com/bytecodealliance/rustix", rev = "397155aa086fcdddb85319a4ae73652a27a0ab44" }

--- a/test-crates/no-std/src/main.rs
+++ b/test-crates/no-std/src/main.rs
@@ -10,7 +10,8 @@ extern crate alloc;
 
 use alloc::boxed::Box;
 use atomic_dbg::{dbg, eprintln};
-use origin::*;
+use origin::thread::*;
+use origin::program::*;
 
 #[panic_handler]
 fn panic(panic: &core::panic::PanicInfo<'_>) -> ! {

--- a/test-crates/origin-start-no-alloc/.cargo/config.toml
+++ b/test-crates/origin-start-no-alloc/.cargo/config.toml
@@ -1,0 +1,3 @@
+# Pass -nostartfiles to the linker.
+[build]
+rustflags = ["-C", "link-args=-nostartfiles"]

--- a/test-crates/origin-start-no-alloc/Cargo.toml
+++ b/test-crates/origin-start-no-alloc/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "origin-start"
+name = "origin-start-no-alloc"
 version = "0.0.0"
 edition = "2021"
 publish = false
@@ -7,11 +7,10 @@ publish = false
 [dependencies]
 # Origin can be depended on just like any other crate. For no_std, disable
 # the default features, and the desired features.
-origin = { path = "../..", default-features = false, features = ["origin-program", "origin-thread", "origin-start"] }
+origin = { path = "../..", default-features = false, features = ["origin-program", "origin-start"] }
 
 # Crates to help writing no_std code.
 atomic-dbg = { version = "0.1.7", default-features = false }
-rustix-dlmalloc = { version = "0.1.0", features = ["global"] }
 compiler_builtins = { version = "0.1.101", features = ["mem"] }
 
 # This is just an example crate, and not part of the origin workspace.

--- a/test-crates/origin-start-no-alloc/README.md
+++ b/test-crates/origin-start-no-alloc/README.md
@@ -1,0 +1,9 @@
+This crate demonstrates the use of origin as a plain library API using
+`no_std` and `no_main`.
+
+This version uses `-nostartfiles` and origin is in control from the very
+beginning. This uses origin in an "origin-start" configuration.
+
+This crate must be built with an explicit `--target` argument, which may be
+the same as the host, because the existence of `--target` prevents the
+`-nostartfile` from being passed to build scripts.

--- a/test-crates/origin-start-no-alloc/src/main.rs
+++ b/test-crates/origin-start-no-alloc/src/main.rs
@@ -1,0 +1,31 @@
+//! A simple example using `no_std` and `no_main` and origin's start.
+
+#![no_std]
+#![no_main]
+#![allow(internal_features)]
+#![feature(lang_items)]
+#![feature(core_intrinsics)]
+
+extern crate compiler_builtins;
+
+use atomic_dbg::{dbg, eprintln};
+use origin::program::*;
+
+#[panic_handler]
+fn panic(panic: &core::panic::PanicInfo<'_>) -> ! {
+    dbg!(panic);
+    core::intrinsics::abort();
+}
+
+#[lang = "eh_personality"]
+extern "C" fn eh_personality() {}
+
+#[no_mangle]
+extern "C" fn main(_argc: i32, _argv: *const *const u8) -> i32 {
+    eprintln!("Hello!");
+
+    // Unlike origin-start, this example can't create threads because origin's
+    // thread support requires an allocator.
+
+    exit(0);
+}

--- a/test-crates/origin-start/src/main.rs
+++ b/test-crates/origin-start/src/main.rs
@@ -11,7 +11,8 @@ extern crate compiler_builtins;
 
 use alloc::boxed::Box;
 use atomic_dbg::{dbg, eprintln};
-use origin::*;
+use origin::thread::*;
+use origin::program::*;
 
 #[panic_handler]
 fn panic(panic: &core::panic::PanicInfo<'_>) -> ! {

--- a/tests/test_crates.rs
+++ b/tests/test_crates.rs
@@ -136,3 +136,8 @@ fn test_crate_origin_start() {
     Hello from an at_exit handler\n",
     );
 }
+
+#[test]
+fn test_crate_origin_start_no_alloc() {
+    test_crate("origin-start-no-alloc", "", "", "Hello!\n");
+}


### PR DESCRIPTION
Put all allocation behind cargo feature "alloc", and add a origin-start-no-alloc example showing how to use origin without a global allocator.

Also, reorganize origin's public API around public "program", "thread", and "signal" modules, which should keep it tidier as we add more features, and make it eaiser to avoid rustix features when they aren't needed.