### PR TITLE
Handle `AT_PHENT` and `DT_RELENT` having unexpected sizes.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -97,5 +97,5 @@ features = ["origin-program", "origin-thread", "origin-signal", "origin-start"]
 rustdoc-args = ["--cfg", "doc_cfg"]
 
 [patch.crates-io]
-# Temporary override for the `runtime::entry` function.
-rustix = { git = "https://github.com/bytecodealliance/rustix", rev = "6697a9f123130c4cd0290f4cec578a83ae405a2c" }
+# Temporary override.
+rustix = { git = "https://github.com/bytecodealliance/rustix", rev = "2c56e44190eb97b5fefabe6cba4f86c50a01db1e" }

--- a/example-crates/basic/Cargo.toml
+++ b/example-crates/basic/Cargo.toml
@@ -10,3 +10,7 @@ origin = { path = "../.." }
 
 # This is just an example crate, and not part of the origin workspace.
 [workspace]
+
+[patch.crates-io]
+# Temporary override.
+rustix = { git = "https://github.com/bytecodealliance/rustix", rev = "2c56e44190eb97b5fefabe6cba4f86c50a01db1e" }

--- a/example-crates/external-start/Cargo.toml
+++ b/example-crates/external-start/Cargo.toml
@@ -21,5 +21,5 @@ compiler_builtins = { version = "0.1.101", features = ["mem"] }
 [workspace]
 
 [patch.crates-io]
-# Temporary override for the `runtime::entry` function.
-rustix = { git = "https://github.com/bytecodealliance/rustix", rev = "6697a9f123130c4cd0290f4cec578a83ae405a2c" }
+# Temporary override.
+rustix = { git = "https://github.com/bytecodealliance/rustix", rev = "2c56e44190eb97b5fefabe6cba4f86c50a01db1e" }

--- a/example-crates/no-std/Cargo.toml
+++ b/example-crates/no-std/Cargo.toml
@@ -17,5 +17,5 @@ rustix-dlmalloc = { version = "0.1.0", features = ["global"] }
 [workspace]
 
 [patch.crates-io]
-# Temporary override for the `runtime::entry` function.
-rustix = { git = "https://github.com/bytecodealliance/rustix", rev = "6697a9f123130c4cd0290f4cec578a83ae405a2c" }
+# Temporary override.
+rustix = { git = "https://github.com/bytecodealliance/rustix", rev = "2c56e44190eb97b5fefabe6cba4f86c50a01db1e" }

--- a/example-crates/origin-start-lto/Cargo.toml
+++ b/example-crates/origin-start-lto/Cargo.toml
@@ -26,5 +26,5 @@ lto = true
 lto = true
 
 [patch.crates-io]
-# Temporary override for the `runtime::entry` function.
-rustix = { git = "https://github.com/bytecodealliance/rustix", rev = "6697a9f123130c4cd0290f4cec578a83ae405a2c" }
+# Temporary override.
+rustix = { git = "https://github.com/bytecodealliance/rustix", rev = "2c56e44190eb97b5fefabe6cba4f86c50a01db1e" }

--- a/example-crates/origin-start-no-alloc/Cargo.toml
+++ b/example-crates/origin-start-no-alloc/Cargo.toml
@@ -17,5 +17,5 @@ compiler_builtins = { version = "0.1.101", features = ["mem"] }
 [workspace]
 
 [patch.crates-io]
-# Temporary override for the `runtime::entry` function.
-rustix = { git = "https://github.com/bytecodealliance/rustix", rev = "6697a9f123130c4cd0290f4cec578a83ae405a2c" }
+# Temporary override.
+rustix = { git = "https://github.com/bytecodealliance/rustix", rev = "2c56e44190eb97b5fefabe6cba4f86c50a01db1e" }

--- a/example-crates/origin-start/Cargo.toml
+++ b/example-crates/origin-start/Cargo.toml
@@ -18,5 +18,5 @@ compiler_builtins = { version = "0.1.101", features = ["mem"] }
 [workspace]
 
 [patch.crates-io]
-# Temporary override for the `runtime::entry` function.
-rustix = { git = "https://github.com/bytecodealliance/rustix", rev = "6697a9f123130c4cd0290f4cec578a83ae405a2c" }
+# Temporary override.
+rustix = { git = "https://github.com/bytecodealliance/rustix", rev = "2c56e44190eb97b5fefabe6cba4f86c50a01db1e" }


### PR DESCRIPTION
ELF is designed to allow these sizes to grow over time, so handle their sizes dynamically instead of statically.