### PR TITLE
Optimizations for code size, and a new minimal-code-size example

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -22,13 +22,10 @@ jobs:
       QEMU_BUILD_VERSION: 8.1.0
     strategy:
       matrix:
-        build: [ubuntu, ubuntu-20.04, i686-linux, aarch64-linux, riscv64-linux]
+        build: [ubuntu, i686-linux, aarch64-linux, riscv64-linux]
         include:
           - build: ubuntu
             os: ubuntu-latest
-            host_target: x86_64-unknown-linux-gnu
-          - build: ubuntu-20.04
-            os: ubuntu-20.04
             host_target: x86_64-unknown-linux-gnu
           - build: i686-linux
             os: ubuntu-latest

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -65,12 +65,12 @@ origin-thread = ["memoffset", "rustix/runtime", "origin-program", "thread"]
 origin-signal = ["rustix/runtime", "signal"]
 
 # Use origin's `_start` definition.
-origin-start = ["rustix/use-explicitly-provided-auxv", "rustix/param", "rustix/runtime"]
+origin-start = ["rustix/use-explicitly-provided-auxv", "rustix/runtime"]
 
 # Don't use origin's `_start` definition, but export a `start` function which
 # is meant to be run very early in program startup and passed a pointer to
 # the initial stack. Don't enable this when enabling "origin-start".
-external-start = ["rustix/use-explicitly-provided-auxv", "rustix/param", "rustix/runtime"]
+external-start = ["rustix/use-explicitly-provided-auxv", "rustix/runtime"]
 
 # Disable logging.
 max_level_off = ["log/max_level_off"]
@@ -83,14 +83,17 @@ alloc = ["rustix/alloc"]
 #
 # Origin's threads support currently depends on dynamic allocation, so it
 # pulls in the "alloc" feature.
-thread = ["alloc", "rustix/thread", "rustix/mm", "rustix/param", "rustix/process", "rustix/runtime"]
+thread = ["alloc", "rustix/thread", "rustix/mm", "param", "rustix/process", "rustix/runtime"]
 
 # Enable support for signal handlers.
 signal = ["rustix/runtime"]
 
+# Enable support for `rustix::param`.
+param = ["rustix/param"]
+
 # Enable highly experimental support for performing startup-time relocations,
 # needed to support statically-linked PIE executables.
-experimental-relocate = ["rustix/mm", "rustix/runtime"]
+experimental-relocate = ["rustix/mm", "rustix/runtime", "param"]
 
 [package.metadata.docs.rs]
 features = ["origin-program", "origin-thread", "origin-signal", "origin-start"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,7 +44,7 @@ features = [ "unwinder" ]
 assert_cmd = "2.0.12"
 
 [features]
-default = ["std", "log", "libc", "thread"]
+default = ["std", "log", "libc", "thread", "init-fini-arrays"]
 std = ["rustix/std"]
 set_thread_id = []
 rustc-dep-of-std = [
@@ -90,6 +90,9 @@ signal = ["rustix/runtime"]
 
 # Enable support for `rustix::param`.
 param = ["rustix/param"]
+
+# Enable support for ELF `.init_array` and `.fini_array`.
+init-fini-arrays = []
 
 # Enable highly experimental support for performing startup-time relocations,
 # needed to support statically-linked PIE executables.

--- a/README.md
+++ b/README.md
@@ -57,6 +57,9 @@ Origin can also be used on its own, in several different configurations:
 
  - The [origin-start-lto example] is like origin-start, but builds with LTO.
 
+ - The [origin-start-tiny example] is like origin-start, but builds with
+   optimization flags and disables features to build a very small binary.
+
 ## Fully static linking
 
 The resulting executables in the origin-start, origin-start-no-alloc, and

--- a/example-crates/origin-start-tiny/.cargo/config.toml
+++ b/example-crates/origin-start-tiny/.cargo/config.toml
@@ -1,0 +1,3 @@
+[build]
+# Disable traps on unreachable code.
+rustflags = ["-Z", "trap-unreachable=no"]

--- a/example-crates/origin-start-tiny/Cargo.toml
+++ b/example-crates/origin-start-tiny/Cargo.toml
@@ -1,0 +1,27 @@
+[package]
+name = "origin-start-tiny"
+version = "0.0.0"
+edition = "2021"
+publish = false
+
+[dependencies]
+# Origin can be depended on just like any other crate. For no_std, disable
+# the default features, and the desired features.
+origin = { path = "../..", default-features = false, features = ["origin-program", "origin-start"] }
+
+# Crates to help writing no_std code.
+compiler_builtins = { version = "0.1.101", features = ["mem"] }
+
+# This is just an example crate, and not part of the origin workspace.
+[workspace]
+
+# Let's optimize for small size!
+[profile.release]
+# Give the optimizer more lattitude to optimize and delete unneeded code.
+lto = true
+# "abort" is smaller than "unwind".
+panic = "abort"
+# Tell the optimizer to optimize for size.
+opt-level = "z"
+# Delete the symbol table from the executable.
+strip = true

--- a/example-crates/origin-start-tiny/README.md
+++ b/example-crates/origin-start-tiny/README.md
@@ -1,0 +1,234 @@
+This crate is similar to the [`origin-start` example], except that doesn't
+print any output, and enables optimizations for small code size. To produce a
+small binary, compile with `--release`.
+
+To produce an even smaller binary, use `objcopy` to remove the `.eh_frame`
+and `.comment` sections:
+
+```
+objcopy -R .eh_frame -R .comment target/release/origin-start-tiny even-smaller
+```
+
+For details on the specific optimizations performed, see the options under
+`[profile.release]` and the use of `default-features = false`, in Cargo.toml,
+and the additional link flags passed in build.rs.
+
+## The optimizations
+
+First, `origin` makes much of its functionality optional, so we add
+`default-features = false` to disable things like `.init_array`/`.fini_array`
+support, thread support, and other things. We only enable the features needed
+for our minimal test program:
+
+```toml
+origin = { path = "../..", default-features = false, features = ["origin-program", "origin-start"] }
+```
+
+Then, we enable several optimizations in the `#[profile.release]` section of
+Cargo.toml:
+
+```toml
+# Give the optimizer more lattitude to optimize and delete unneeded code.
+lto = true
+# "abort" is smaller than "unwind".
+panic = "abort"
+# Tell the optimizer to optimize for size.
+opt-level = "z"
+# Delete the symbol table from the executable.
+strip = true
+```
+
+In detail:
+
+> `lto = true`
+
+LTO is Link-Time Optimization, which gives the optimizer the ability to see the
+whole program at once, and be more aggressive about deleting unneeded code.
+
+For example, in our test program, it enables inlining of the `main` function
+into the code in `origin` that calls it. Since it's just returning the constant
+`42`, inlining reduces code size.
+
+> `panic = "abort"`
+
+Rust's default panic mechanism is to perform a stack unwind, however that
+mechanism takes some code.
+
+This doesn't actally help our example here, since it's a minimal program that
+doesn't contain any `panic` calls, but it's a useful optimization feature in
+general.
+
+> `opt-level = "z"`
+
+The "z" optimization level instructs the compiler to prioritize code size above
+all other considerations.
+
+For example, on x86-64, in our test program, it uses this code sequence to load
+the value `0x2a`, which is our return value of `42`, into the `%rdi` register
+to pass to the exit system call:
+
+```asm
+  4000bc:	6a 2a                	push   $0x2a
+  4000be:	5f                   	pop    %rdi
+```
+
+Compare that with the sequence it emits without "z":
+
+```asm
+  4000c1:	bf 2a 00 00 00       	mov    $0x2a,%edi
+```
+
+The "z" form is two instructions rather than one. It also does a store and a
+load, as well as a stack pointer subtract and add. Modern x86-64 processors do
+store-to-load forwarding to avoid actually writing to memory and have a Stack
+engine for `push`/`pop` sequences and are very good at optimizing those kinds
+of instruction sequences; see Agner's
+[The microarchitecture of Intel, AMD, and VIA CPUs] for more information.
+However, even with these fancy features, it's probably still not completely
+free.
+
+But it is 3 bytes instead of 5, so `opt_level = "z"` goes with it.
+
+Amusingly, it doesn't do this same trick for the immediately following
+instruction, which looks similar:
+```
+  4000bd:	b8 e7 00 00 00       	mov    $0xe7,%eax
+```
+
+Here, the value being loaded is 0xe7, which has the eigth bit set. The x86
+`push` instructions immediate field is signed, so `push $0xe7` would need a
+4-byte immediate field to zero-extend it. Consequently, using the `push`/`pop`
+trick in this case would be longer.
+
+Next, we enable several link arguments in build.rs:
+
+```rust
+    // Tell the linker to exclude the .eh_frame_hdr section.
+    println!("cargo:rustc-link-arg=-Wl,--no-eh-frame-hdr");
+    // Tell the linker not to page-align sections.
+    println!("cargo:rustc-link-arg=-Wl,-n");
+    // Tell the linker to make the text and data readable and writeable. This
+    // allows them to occupy the same page.
+    println!("cargo:rustc-link-arg=-Wl,-N");
+    // Tell the linker to exclude the `.note.gnu.build-id` section.
+    println!("cargo:rustc-link-arg=-Wl,--build-id=none");
+    // Disable PIE, which adds some code size.
+    println!("cargo:rustc-link-arg=-Wl,--no-pie");
+    // Disable the `GNU-stack` segment, if we're using lld.
+    println!("cargo:rustc-link-arg=-Wl,-z,nognustack");
+```
+
+In detail:
+
+> `--no-eh-frame-hdr`
+
+This disables the creation of a `.eh_frame_hdr` section, which we don't need
+since we won't be doing any unwinding.
+
+> `-n`
+
+This turns of page alignment of sections, so that we don't waste any space on
+padding bytes.
+
+> `-N`
+
+This sets code sections to be writable, so that they can be loaded into memory
+together with data. Ordinarily, having read-only code is a very good thing,
+but making them writable can save a few bytes.
+
+The `-n` and `-N` flags dont actally help our example here, but they can save
+some code size in larger programs.
+
+> `--build-id=none`
+
+This disables the creation of a `.note.gnu.build-id` section, which is used by
+some build tools. We're not using any extra tools in our simple example here,
+so we can disable this.
+
+> `--no-pie`
+
+Position-Independent Executables (PIE) are executables that can be loaded into
+a random address in memory, to make some kinds of security exploits harder,
+though it takes some extra code and relocation metadata to fix up addresses
+once the actual runtime address has been determined. Our simple example here
+isn't concerned with security, so we can disable this feature and save the
+space.
+
+> -z nognustack
+
+This option is only recognized by ld.lld, so if you happen to be using that,
+this disables the use of the `GNU-stack` feature which allows the OS to mark
+the stack as non-executable. A non-executable stack is a very good thing, but
+omitting this request does save a few bytes.
+
+Finally, we add a RUSTFLAGS flag with .cargo/config.toml:
+
+```toml
+rustflags = ["-Z", "trap-unreachable=no"]
+```
+
+This disables the use of trap instructions, such as `ud2` on x86-64, at places
+the compiler thinks should be unreachable, such as after the `jmp` in `_start`
+or after the `syscall` that calls `exit_group`, because rustix uses the
+`noreturn` [inline asm option]. Normally this is a very good thing, but it
+does take a few extra bytes.
+
+[inline asm option]: https://doc.rust-lang.org/reference/inline-assembly.html#options
+
+## Generated code
+
+With all these optimizations, the generated code looks like this:
+
+```asm
+00000000004000b0 <.text>:
+  4000b0:	48 89 e7             	mov    %rsp,%rdi
+  4000b3:	55                   	push   %rbp
+  4000b4:	e9 00 00 00 00       	jmp    0x4000b9
+  4000b9:	50                   	push   %rax
+  4000ba:	6a 2a                	push   $0x2a
+  4000bc:	5f                   	pop    %rdi
+  4000bd:	b8 e7 00 00 00       	mov    $0xe7,%eax
+  4000c2:	0f 05                	syscall 
+```
+
+Those first 3 instructions are origin's `_start` function. The next 5
+instructions are `origin::program::entry` and everything, including the user
+`main` function and the `exit_group` syscall inlined into it.
+
+In theory this code code be made even smaller.
+
+That first `mov $rsp,%rdi` is moving the incoming stack pointer we got from the
+OS into the first argument register to pass to `origin::program::entry` so that
+it can use it to pick up the command-line arguments, environment variables, and
+AUX records, however we don't use any of those, so we don't need that argument.
+In theory origin could put that behind a cargo flag, but I didn't feel like
+adding separate versions of the `_start` sequence just for that optimization.
+
+Also, in theory, `origin::program::entry` could use the
+`llvm.frameaddress intrinsic` to read the incoming stack pointer value, instead
+of needing an explicit argument. But having it be an explicit argument makes it
+behave more like normal Rust code, which shouldn't be peeking at its caller's
+stack memory.
+
+And lastly, we could enable the `push %rbp`, `jmp`, and `push %rax`, which are
+just zeroing out the return address so that nothing ever unwinds back into the
+`_start` code, jumping to the immediately following code, and aligning the
+stack pointer, all to make a "call" from the `[naked]` function `_start` written
+in asm to the Rust `origin::program::entry` function. This is the transition
+from assembly code to the first Rust code in the program. There are sneaky ways
+to arrange for this code to be able to fall-through from `_start` into the
+`origin::program::entry`, but as above, I'm aiming to have this code behave
+like normal Rust code, which shouldn't be using control flow paths that the
+compiler doesn't know about.
+
+## Sources
+
+Many of these optimizations came from the following websites:
+
+ - [Minimizing Rust Binary Size](https://github.com/johnthagen/min-sized-rust),
+   a great general-purpose resource.
+ - [A very small Rust binary indeed](https://darkcoding.net/software/a-very-small-rust-binary-indeed/),
+   a great resource for more extreme code-size optimizations.
+
+[origin-start example]: https://github.com/sunfishcode/origin/blob/main/example-crates/origin-start/README.md
+[The microarchitecture of Intel, AMD, and VIA CPUs]: https://www.agner.org/optimize/microarchitecture.pdf

--- a/example-crates/origin-start-tiny/build.rs
+++ b/example-crates/origin-start-tiny/build.rs
@@ -1,0 +1,21 @@
+fn main() {
+    // Pass -nostartfiles to the linker. In the future this could be obviated
+    // by a `no_entry` feature: <https://github.com/rust-lang/rfcs/pull/2735>
+    println!("cargo:rustc-link-arg=-nostartfiles");
+
+    // The following options optimize for code size!
+
+    // Tell the linker to exclude the .eh_frame_hdr section.
+    println!("cargo:rustc-link-arg=-Wl,--no-eh-frame-hdr");
+    // Tell the linker not to page-align sections.
+    println!("cargo:rustc-link-arg=-Wl,-n");
+    // Tell the linker to make the text and data readable and writeable. This
+    // allows them to occupy the same page.
+    println!("cargo:rustc-link-arg=-Wl,-N");
+    // Tell the linker to exclude the `.note.gnu.build-id` section.
+    println!("cargo:rustc-link-arg=-Wl,--build-id=none");
+    // Disable PIE, which adds some code size.
+    println!("cargo:rustc-link-arg=-Wl,--no-pie");
+    // Disable the `GNU-stack` segment, if we're using lld.
+    println!("cargo:rustc-link-arg=-Wl,-z,nognustack");
+}

--- a/example-crates/origin-start-tiny/src/main.rs
+++ b/example-crates/origin-start-tiny/src/main.rs
@@ -1,0 +1,23 @@
+//! Going for minimal size!
+
+#![no_std]
+#![no_main]
+#![allow(internal_features)]
+#![feature(lang_items)]
+#![feature(core_intrinsics)]
+
+extern crate origin;
+extern crate compiler_builtins;
+
+#[panic_handler]
+fn panic(_panic: &core::panic::PanicInfo<'_>) -> ! {
+    core::intrinsics::abort()
+}
+
+#[lang = "eh_personality"]
+extern "C" fn eh_personality() {}
+
+#[no_mangle]
+extern "C" fn main(_argc: i32, _argv: *const *const u8) -> i32 {
+    42
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,8 +13,12 @@
 #[cfg(all(feature = "alloc", not(feature = "rustc-dep-of-std")))]
 extern crate alloc;
 
+// Pull in the `unwinding` crate to satisfy `_Unwind_* symbol references.
+// Except that 32-bit arm isn't supported yet, so we use stubs instead.
 #[cfg(not(target_arch = "arm"))]
 extern crate unwinding;
+#[cfg(target_arch = "arm")]
+mod unwind;
 
 pub mod program;
 #[cfg(feature = "signal")]
@@ -27,10 +31,6 @@ pub mod signal;
 #[cfg_attr(feature = "origin-thread", path = "thread/linux_raw.rs")]
 #[cfg_attr(not(feature = "origin-thread"), path = "thread/libc.rs")]
 pub mod thread;
-
-// Unwinding isn't supported on 32-bit arm yet.
-#[cfg(target_arch = "arm")]
-mod unwind;
 
 #[cfg(any(feature = "origin-thread", feature = "origin-signal"))]
 #[cfg_attr(target_arch = "aarch64", path = "arch/aarch64.rs")]

--- a/src/program.rs
+++ b/src/program.rs
@@ -338,7 +338,7 @@ unsafe fn relocate() {
     let (first_phdr, phent, phnum) = rustix::runtime::exe_phdrs();
     let mut current_phdr = first_phdr.cast::<Elf_Phdr>();
 
-    // Next, look through the Phdrs to find the Dynamic section and the Relro
+    // Next, look through the Phdrs to find the Dynamic section and the relro
     // description if present. In the `Dynamic` section, find the relocations
     // and perform them.
     let mut relro = 0;
@@ -394,7 +394,7 @@ unsafe fn relocate() {
                 }
             }
             PT_GNU_RELRO => {
-                // A Relro description is present. Make a note of it so that we
+                // A relro description is present. Make a note of it so that we
                 // can mark memory readonly after relocations are done.
                 relro = phdr.p_vaddr;
                 relro_len = phdr.p_memsz;
@@ -413,7 +413,7 @@ unsafe fn relocate() {
         assert_eq!(static_start, dynamic_start);
     }
 
-    // If we saw a Relro description, mark the memory readonly.
+    // If we saw a relro description, mark the memory readonly.
     if relro_len != 0 {
         let mprotect_addr =
             from_exposed_addr_mut(relro.wrapping_add(offset) & page_size().wrapping_neg());

--- a/src/program.rs
+++ b/src/program.rs
@@ -82,6 +82,7 @@ pub(super) unsafe extern "C" fn entry(mem: *mut usize) -> ! {
 
     // Explicitly initialize `rustix` so that we can control the initialization
     // order.
+    #[cfg(feature = "param")]
     rustix::param::init(envp);
 
     // After initializing the AUX data in rustix, but before doing anything

--- a/src/program.rs
+++ b/src/program.rs
@@ -30,6 +30,8 @@ use rustix_futex_sync::Mutex;
 /// `mem` should point to the stack as provided by the operating system.
 #[cfg(any(feature = "origin-start", feature = "external-start"))]
 pub(super) unsafe extern "C" fn entry(mem: *mut usize) -> ! {
+    use linux_raw_sys::ctypes::c_uint;
+
     extern "C" {
         fn main(argc: c_int, argv: *mut *mut u8, envp: *mut *mut u8) -> c_int;
     }
@@ -75,7 +77,7 @@ pub(super) unsafe extern "C" fn entry(mem: *mut usize) -> ! {
     // Compute `argc`, `argv`, and `envp`.
     let argc = *mem as c_int;
     let argv = mem.add(1).cast::<*mut u8>();
-    let envp = argv.add(argc as usize + 1);
+    let envp = argv.add(argc as c_uint as usize + 1);
 
     // Do a few more precondition checks on `argc` and `argv`.
     debug_assert!(argc >= 0);

--- a/src/unwind.rs
+++ b/src/unwind.rs
@@ -1,7 +1,7 @@
-//! Stub libunwind implementation on platforms where we don't have real
-//! unwind support.
+//! Stub libunwind implementation on platforms where we don't have real unwind
+//! support.
 //!
-//! Entirely `unimplemented!`. Don't panic.
+//! Entirely `unimplemented!`.
 
 #[no_mangle]
 unsafe extern "C" fn _Unwind_Backtrace() {

--- a/tests/example_crates.rs
+++ b/tests/example_crates.rs
@@ -9,6 +9,7 @@ fn test_crate(
     envs: &[(&str, &str)],
     stdout: &'static str,
     stderr: &'static str,
+    code: Option<i32>,
 ) {
     use assert_cmd::Command;
 
@@ -17,7 +18,13 @@ fn test_crate(
     command.args(args);
     command.envs(envs.iter().cloned());
     command.current_dir(format!("example-crates/{}", name));
-    command.assert().stdout(stdout).stderr(stderr).success();
+    let assert = command.assert();
+    let assert = assert.stdout(stdout).stderr(stderr);
+    if let Some(code) = code {
+        assert.code(code);
+    } else {
+        assert.success();
+    }
 }
 
 /// Stderr output for most of the example crates.
@@ -33,7 +40,7 @@ const NO_ALLOC_STDERR: &'static str = "Hello!\n";
 
 #[test]
 fn example_crate_basic() {
-    test_crate("basic", &[], &[], "", COMMON_STDERR);
+    test_crate("basic", &[], &[], "", COMMON_STDERR, None);
 }
 
 /// Like `example_crate_basic` but redundantly call `relocate`.
@@ -45,12 +52,13 @@ fn example_crate_basic_relocate() {
         &[],
         "",
         COMMON_STDERR,
+        None,
     );
 }
 
 #[test]
 fn example_crate_no_std() {
-    test_crate("no-std", &[], &[], "", COMMON_STDERR);
+    test_crate("no-std", &[], &[], "", COMMON_STDERR, None);
 }
 
 /// Like `example_crate_no_std` but redundantly call `relocate`.
@@ -62,12 +70,13 @@ fn example_crate_no_std_relocate() {
         &[],
         "",
         COMMON_STDERR,
+        None,
     );
 }
 
 #[test]
 fn example_crate_external_start() {
-    test_crate("external-start", &[], &[], "", COMMON_STDERR);
+    test_crate("external-start", &[], &[], "", COMMON_STDERR, None);
 }
 
 /// Like `example_crate_external_start` but redundantly call `relocate`.
@@ -79,13 +88,14 @@ fn example_crate_external_start_relocate() {
         &[],
         "",
         COMMON_STDERR,
+        None,
     );
 }
 
 #[test]
 fn example_crate_origin_start() {
     // Use a dynamic linker.
-    test_crate("origin-start", &[], &[], "", COMMON_STDERR);
+    test_crate("origin-start", &[], &[], "", COMMON_STDERR, None);
 }
 
 /// Use a dynamic linker, redundantly run `relocate`.
@@ -97,6 +107,7 @@ fn example_crate_origin_start_relocate() {
         &[],
         "",
         COMMON_STDERR,
+        None,
     );
 }
 
@@ -109,6 +120,7 @@ fn example_crate_origin_start_crt_static() {
         &[("RUSTFLAGS", "-C target-feature=+crt-static")],
         "",
         COMMON_STDERR,
+        None,
     );
 }
 
@@ -124,6 +136,7 @@ fn example_crate_origin_start_crt_static_relocation_static() {
         )],
         "",
         COMMON_STDERR,
+        None,
     );
 }
 
@@ -139,13 +152,14 @@ fn example_crate_origin_start_crt_static_relocation_static_relocate() {
         )],
         "",
         COMMON_STDERR,
+        None,
     );
 }
 
 /// Use a dynamic linker.
 #[test]
 fn example_crate_origin_start_no_alloc() {
-    test_crate("origin-start-no-alloc", &[], &[], "", NO_ALLOC_STDERR);
+    test_crate("origin-start-no-alloc", &[], &[], "", NO_ALLOC_STDERR, None);
 }
 
 /// Use a dynamic linker, redundantly run `relocate`.
@@ -157,6 +171,7 @@ fn example_crate_origin_start_no_alloc_relocate() {
         &[],
         "",
         NO_ALLOC_STDERR,
+        None,
     );
 }
 
@@ -169,6 +184,7 @@ fn example_crate_origin_start_no_alloc_crt_static() {
         &[("RUSTFLAGS", "-C target-feature=+crt-static")],
         "",
         NO_ALLOC_STDERR,
+        None,
     );
 }
 
@@ -184,6 +200,7 @@ fn example_crate_origin_start_no_alloc_crt_static_relocation_static() {
         )],
         "",
         NO_ALLOC_STDERR,
+        None,
     );
 }
 
@@ -199,13 +216,21 @@ fn example_crate_origin_start_no_alloc_crt_static_relocation_static_relocate() {
         )],
         "",
         NO_ALLOC_STDERR,
+        None,
     );
 }
 
 #[test]
 fn example_crate_origin_start_lto() {
     // Use a dynamic linker.
-    test_crate("origin-start-lto", &["--release"], &[], "", COMMON_STDERR);
+    test_crate(
+        "origin-start-lto",
+        &["--release"],
+        &[],
+        "",
+        COMMON_STDERR,
+        None,
+    );
 }
 
 /// Use a dynamic linker, redundantly run `relocate`.
@@ -217,6 +242,7 @@ fn example_crate_origin_start_lto_relocate() {
         &[],
         "",
         COMMON_STDERR,
+        None,
     );
 }
 
@@ -229,6 +255,7 @@ fn example_crate_origin_start_lto_crt_static() {
         &[("RUSTFLAGS", "-C target-feature=+crt-static")],
         "",
         COMMON_STDERR,
+        None,
     );
 }
 
@@ -244,6 +271,7 @@ fn example_crate_origin_start_lto_crt_static_relocation_static() {
         )],
         "",
         COMMON_STDERR,
+        None,
     );
 }
 
@@ -259,5 +287,11 @@ fn example_crate_origin_start_lto_crt_static_relocation_static_relocate() {
         )],
         "",
         COMMON_STDERR,
+        None,
     );
+}
+
+#[test]
+fn example_crate_origin_start_tiny() {
+    test_crate("origin-start-tiny", &["--release"], &[], "", "", Some(42));
 }


### PR DESCRIPTION
This adds several optimizations for small code size, and adds a new origin-start-tiny example demonstrating them, and a README.md entry detailing all the special options.