### PR TITLE
Change main function to use extern rust instead of C

### DIFF
--- a/src/program.rs
+++ b/src/program.rs
@@ -28,7 +28,7 @@ use rustix_futex_sync::Mutex;
 /// `mem` should point to the stack as provided by the operating system.
 #[cfg(any(feature = "origin-start", feature = "external-start"))]
 pub(super) unsafe extern "C" fn entry(mem: *mut usize) -> ! {
-    extern "C" {
+    extern "Rust" {
         fn main(argc: c_int, argv: *mut *mut u8, envp: *mut *mut u8) -> c_int;
     }
 

--- a/test-crates/external-start/src/main.rs
+++ b/test-crates/external-start/src/main.rs
@@ -56,7 +56,7 @@ static EARLY_INIT_ARRAY: unsafe extern "C" fn(i32, *mut *mut u8) = {
 };
 
 #[no_mangle]
-extern "C" fn main(_argc: i32, _argv: *const *const u8) -> i32 {
+fn main(_argc: i32, _argv: *const *const u8) -> i32 {
     eprintln!("Hello from main thread");
 
     at_exit(Box::new(|| eprintln!("Hello from an at_exit handler")));

--- a/test-crates/origin-start-no-alloc/src/main.rs
+++ b/test-crates/origin-start-no-alloc/src/main.rs
@@ -21,7 +21,7 @@ fn panic(panic: &core::panic::PanicInfo<'_>) -> ! {
 extern "C" fn eh_personality() {}
 
 #[no_mangle]
-extern "C" fn main(_argc: i32, _argv: *const *const u8) -> i32 {
+fn main(_argc: i32, _argv: *const *const u8) -> i32 {
     eprintln!("Hello!");
 
     // Unlike origin-start, this example can't create threads because origin's

--- a/test-crates/origin-start/src/main.rs
+++ b/test-crates/origin-start/src/main.rs
@@ -11,8 +11,8 @@ extern crate compiler_builtins;
 
 use alloc::boxed::Box;
 use atomic_dbg::{dbg, eprintln};
-use origin::thread::*;
 use origin::program::*;
+use origin::thread::*;
 
 #[panic_handler]
 fn panic(panic: &core::panic::PanicInfo<'_>) -> ! {
@@ -27,7 +27,7 @@ extern "C" fn eh_personality() {}
 static GLOBAL_ALLOCATOR: rustix_dlmalloc::GlobalDlmalloc = rustix_dlmalloc::GlobalDlmalloc;
 
 #[no_mangle]
-extern "C" fn main(_argc: i32, _argv: *const *const u8) -> i32 {
+fn main(_argc: i32, _argv: *const *const u8) -> i32 {
     eprintln!("Hello from main thread");
 
     at_exit(Box::new(|| eprintln!("Hello from an at_exit handler")));


### PR DESCRIPTION
Currently origin requires users of the library to supply a main function with the following definition
```rust
extern "C" {
    fn main(argc: c_int, argv: *mut *mut u8, envp: *mut *mut u8) -> c_int;
}
```

However it is not necessary to use an `extern C` there since this never crosses any ffi boundary and is always compiled from source. This pr changes this from  an `extern C` to an `extern Rust`. This allows to omit any extern declarations when writing main since the Rust extern is always implied.

Main function before this change:
```rust
#[no_mangle]
extern "C" fn main(argc: i32, argv: *const *const u8) -> i32 {} 
```

Main function after this change
```rust
#[no_mangle] // No mangle is still required since we are still linking from an external library
fn main(argc: i32, argv: *const *const u8) -> i32 {} 
```