### PR TITLE
Change main from extern "C" to extern "Rust"

### DIFF
--- a/example-crates/external-start/src/main.rs
+++ b/example-crates/external-start/src/main.rs
@@ -56,7 +56,7 @@ static EARLY_INIT_ARRAY: unsafe extern "C" fn(i32, *mut *mut u8) = {
 };
 
 #[no_mangle]
-extern "C" fn main(_argc: i32, _argv: *const *const u8) -> i32 {
+fn main(_argc: i32, _argv: *const *const u8) -> i32 {
     eprintln!("Hello from main thread");
 
     at_exit(Box::new(|| eprintln!("Hello from an at_exit handler")));

--- a/example-crates/origin-start-lto/src/main.rs
+++ b/example-crates/origin-start-lto/src/main.rs
@@ -27,7 +27,7 @@ extern "C" fn eh_personality() {}
 static GLOBAL_ALLOCATOR: rustix_dlmalloc::GlobalDlmalloc = rustix_dlmalloc::GlobalDlmalloc;
 
 #[no_mangle]
-extern "C" fn main(_argc: i32, _argv: *const *const u8) -> i32 {
+fn main(_argc: i32, _argv: *const *const u8) -> i32 {
     eprintln!("Hello from main thread");
 
     at_exit(Box::new(|| eprintln!("Hello from an at_exit handler")));

--- a/example-crates/origin-start-no-alloc/src/main.rs
+++ b/example-crates/origin-start-no-alloc/src/main.rs
@@ -21,7 +21,7 @@ fn panic(panic: &core::panic::PanicInfo<'_>) -> ! {
 extern "C" fn eh_personality() {}
 
 #[no_mangle]
-extern "C" fn main(_argc: i32, _argv: *const *const u8) -> i32 {
+fn main(_argc: i32, _argv: *const *const u8) -> i32 {
     eprintln!("Hello!");
 
     // Unlike origin-start, this example can't create threads because origin's

--- a/example-crates/origin-start-tiny/src/main.rs
+++ b/example-crates/origin-start-tiny/src/main.rs
@@ -18,6 +18,6 @@ fn panic(_panic: &core::panic::PanicInfo<'_>) -> ! {
 extern "C" fn eh_personality() {}
 
 #[no_mangle]
-extern "C" fn main(_argc: i32, _argv: *const *const u8) -> i32 {
+fn main(_argc: i32, _argv: *const *const u8) -> i32 {
     42
 }

--- a/example-crates/origin-start/src/main.rs
+++ b/example-crates/origin-start/src/main.rs
@@ -27,7 +27,7 @@ extern "C" fn eh_personality() {}
 static GLOBAL_ALLOCATOR: rustix_dlmalloc::GlobalDlmalloc = rustix_dlmalloc::GlobalDlmalloc;
 
 #[no_mangle]
-extern "C" fn main(_argc: i32, _argv: *const *const u8) -> i32 {
+fn main(_argc: i32, _argv: *const *const u8) -> i32 {
     eprintln!("Hello from main thread");
 
     at_exit(Box::new(|| eprintln!("Hello from an at_exit handler")));

--- a/src/program.rs
+++ b/src/program.rs
@@ -32,7 +32,7 @@ use rustix_futex_sync::Mutex;
 pub(super) unsafe extern "C" fn entry(mem: *mut usize) -> ! {
     use linux_raw_sys::ctypes::c_uint;
 
-    extern "C" {
+    extern "Rust" {
         fn main(argc: c_int, argv: *mut *mut u8, envp: *mut *mut u8) -> c_int;
     }
 


### PR DESCRIPTION
Currently origin requires users of the library to supply a main function with the following definition
```rust
extern "C" {
    fn main(argc: c_int, argv: *mut *mut u8, envp: *mut *mut u8) -> c_int;
}
```

However it is not necessary to use an `extern C` there since this never crosses any ffi boundary and is always compiled from source. This pr changes this from  an `extern C` to an `extern Rust`. This allows to omit any extern declarations when writing main since the Rust extern is always implied.

Main function before this change:
```rust
#[no_mangle]
extern "C" fn main(argc: i32, argv: *const *const u8) -> i32 {} 
```

Main function after this change
```rust
#[no_mangle] // No mangle is still required since we are still linking from an external library
fn main(argc: i32, argv: *const *const u8) -> i32 {} 
```

I had opened #33 at first without realizing I was working with a very outdated branch so this supersedes that