### PR TITLE
Move from an hardcoded extern _start to a dynamic proc_macro

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,9 @@ memoffset = { version = "0.9.0", optional = true }
 log = { version = "0.4.14", default-features = false, optional = true }
 rustix-futex-sync = "0.1.0"
 
+# Provides "origin::main" macro
+origin-macros = { version = "0.1.0", path = "./macros", optional = true }
+
 # Optional logging backends. You can use any external logger, but using these
 # features allows origin to initialize the logger before main, so that you can
 # see the log messages emitted before main is called.
@@ -57,6 +60,8 @@ rustc-dep-of-std = [
     "bitflags/rustc-dep-of-std",
     "libc/rustc-dep-of-std",
 ]
+
+macros = ["dep:origin-macros"]
 
 # Use origin's implementation of program startup and shutdown.
 origin-program = []

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,3 +1,6 @@
+[workspace]
+members = ["macros"]
+
 [package]
 name = "origin"
 version = "0.12.1"

--- a/example-crates/origin-start-lto/Cargo.toml
+++ b/example-crates/origin-start-lto/Cargo.toml
@@ -7,7 +7,7 @@ publish = false
 [dependencies]
 # Origin can be depended on just like any other crate. For no_std, disable
 # the default features, and the desired features.
-origin = { path = "../..", default-features = false, features = ["origin-program", "origin-thread", "origin-start"] }
+origin = { path = "../..", default-features = false, features = ["origin-program", "origin-thread", "origin-start", "macros"] }
 
 # Crates to help writing no_std code.
 atomic-dbg = { version = "0.1.8", default-features = false }

--- a/example-crates/origin-start-lto/src/main.rs
+++ b/example-crates/origin-start-lto/src/main.rs
@@ -5,6 +5,7 @@
 #![allow(internal_features)]
 #![feature(lang_items)]
 #![feature(core_intrinsics)]
+#![feature(naked_functions)]
 
 extern crate alloc;
 extern crate compiler_builtins;
@@ -26,8 +27,8 @@ extern "C" fn eh_personality() {}
 #[global_allocator]
 static GLOBAL_ALLOCATOR: rustix_dlmalloc::GlobalDlmalloc = rustix_dlmalloc::GlobalDlmalloc;
 
-#[no_mangle]
-extern "C" fn main(_argc: i32, _argv: *const *const u8) -> i32 {
+#[origin::main]
+fn main() -> i32 {
     eprintln!("Hello from main thread");
 
     at_exit(Box::new(|| eprintln!("Hello from an at_exit handler")));
@@ -53,5 +54,6 @@ extern "C" fn main(_argc: i32, _argv: *const *const u8) -> i32 {
     }
 
     eprintln!("Goodbye from main");
-    exit(0);
+
+    0
 }

--- a/example-crates/origin-start-no-alloc/Cargo.toml
+++ b/example-crates/origin-start-no-alloc/Cargo.toml
@@ -7,7 +7,7 @@ publish = false
 [dependencies]
 # Origin can be depended on just like any other crate. For no_std, disable
 # the default features, and the desired features.
-origin = { path = "../..", default-features = false, features = ["origin-program", "origin-start"] }
+origin = { path = "../..", default-features = false, features = ["origin-program", "origin-start", "macros"] }
 
 # Crates to help writing no_std code.
 atomic-dbg = { version = "0.1.8", default-features = false }

--- a/example-crates/origin-start-no-alloc/src/main.rs
+++ b/example-crates/origin-start-no-alloc/src/main.rs
@@ -5,11 +5,11 @@
 #![allow(internal_features)]
 #![feature(lang_items)]
 #![feature(core_intrinsics)]
+#![feature(naked_functions)]
 
 extern crate compiler_builtins;
 
 use atomic_dbg::{dbg, eprintln};
-use origin::program::*;
 
 #[panic_handler]
 fn panic(panic: &core::panic::PanicInfo<'_>) -> ! {
@@ -20,12 +20,12 @@ fn panic(panic: &core::panic::PanicInfo<'_>) -> ! {
 #[lang = "eh_personality"]
 extern "C" fn eh_personality() {}
 
-#[no_mangle]
-extern "C" fn main(_argc: i32, _argv: *const *const u8) -> i32 {
+#[origin::main]
+fn start() -> i32 {
     eprintln!("Hello!");
 
     // Unlike origin-start, this example can't create threads because origin's
     // thread support requires an allocator.
 
-    exit(0);
+    0
 }

--- a/example-crates/origin-start-tiny/Cargo.toml
+++ b/example-crates/origin-start-tiny/Cargo.toml
@@ -7,7 +7,7 @@ publish = false
 [dependencies]
 # Origin can be depended on just like any other crate. For no_std, disable
 # the default features, and the desired features.
-origin = { path = "../..", default-features = false, features = ["origin-program", "origin-start"] }
+origin = { path = "../..", default-features = false, features = ["origin-program", "origin-start", "macros"] }
 
 # Crates to help writing no_std code.
 compiler_builtins = { version = "0.1.101", features = ["mem"] }

--- a/example-crates/origin-start-tiny/src/main.rs
+++ b/example-crates/origin-start-tiny/src/main.rs
@@ -5,9 +5,10 @@
 #![allow(internal_features)]
 #![feature(lang_items)]
 #![feature(core_intrinsics)]
+#![feature(naked_functions)]
 
-extern crate origin;
 extern crate compiler_builtins;
+extern crate origin;
 
 #[panic_handler]
 fn panic(_panic: &core::panic::PanicInfo<'_>) -> ! {
@@ -17,7 +18,7 @@ fn panic(_panic: &core::panic::PanicInfo<'_>) -> ! {
 #[lang = "eh_personality"]
 extern "C" fn eh_personality() {}
 
-#[no_mangle]
-extern "C" fn main(_argc: i32, _argv: *const *const u8) -> i32 {
+#[origin::start]
+fn main() -> i32 {
     42
 }

--- a/example-crates/origin-start/Cargo.toml
+++ b/example-crates/origin-start/Cargo.toml
@@ -7,7 +7,7 @@ publish = false
 [dependencies]
 # Origin can be depended on just like any other crate. For no_std, disable
 # the default features, and the desired features.
-origin = { path = "../..", default-features = false, features = ["origin-program", "origin-thread", "origin-start"] }
+origin = { path = "../..", default-features = false, features = ["origin-program", "origin-thread", "origin-start", "macros"] }
 
 # Crates to help writing no_std code.
 atomic-dbg = { version = "0.1.8", default-features = false }

--- a/example-crates/origin-start/src/main.rs
+++ b/example-crates/origin-start/src/main.rs
@@ -5,6 +5,7 @@
 #![allow(internal_features)]
 #![feature(lang_items)]
 #![feature(core_intrinsics)]
+#![feature(naked_functions)]
 
 extern crate alloc;
 extern crate compiler_builtins;
@@ -26,8 +27,8 @@ extern "C" fn eh_personality() {}
 #[global_allocator]
 static GLOBAL_ALLOCATOR: rustix_dlmalloc::GlobalDlmalloc = rustix_dlmalloc::GlobalDlmalloc;
 
-#[no_mangle]
-extern "C" fn main(_argc: i32, _argv: *const *const u8) -> i32 {
+#[origin::main]
+fn main() -> i32 {
     eprintln!("Hello from main thread");
 
     at_exit(Box::new(|| eprintln!("Hello from an at_exit handler")));

--- a/macros/Cargo.toml
+++ b/macros/Cargo.toml
@@ -9,4 +9,4 @@ proc-macro = true
 [dependencies]
 proc-macro2 = "1.0.66"
 quote = "1.0.33"
-syn = "2.0.31"
+syn = { version = "2.0.31", features = ["full"] }

--- a/macros/Cargo.toml
+++ b/macros/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "origin-macros"
+version = "0.1.0"
+edition = "2021"
+
+[lib]
+proc-macro = true
+
+[dependencies]
+proc-macro2 = "1.0.66"
+quote = "1.0.33"
+syn = "2.0.31"

--- a/macros/Cargo.toml
+++ b/macros/Cargo.toml
@@ -2,6 +2,17 @@
 name = "origin-macros"
 version = "0.1.0"
 edition = "2021"
+authors = [
+    "Dan Gohman <dev@sunfishcode.online>",
+    "Federico Maria Morrone <contact@morrone.dev>",
+]
+description = "Macros for origin crate"
+documentation = "https://docs.rs/origin-macros"
+license = "Apache-2.0 WITH LLVM-exception OR Apache-2.0 OR MIT"
+repository = "https://github.com/sunfishcode/origin"
+keywords = ["linux"]
+categories = ["no-std"]
+include = ["src", "Cargo.toml", "../COPYRIGHT", "../LICENSE*", "README.md"]
 
 [lib]
 proc-macro = true

--- a/macros/README.md
+++ b/macros/README.md
@@ -1,0 +1,1 @@
+# Origin Macros

--- a/macros/src/lib.rs
+++ b/macros/src/lib.rs
@@ -1,0 +1,14 @@
+pub fn add(left: usize, right: usize) -> usize {
+    left + right
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn it_works() {
+        let result = add(2, 2);
+        assert_eq!(result, 4);
+    }
+}

--- a/macros/src/lib.rs
+++ b/macros/src/lib.rs
@@ -1,6 +1,32 @@
 use proc_macro::TokenStream;
+use quote::quote;
+use syn::{parse_macro_input, ItemFn};
 
 #[proc_macro_attribute]
-pub fn main(_attr: TokenStream, item: TokenStream) -> TokenStream {
-    item
+pub fn main(_attr: TokenStream, input: TokenStream) -> TokenStream {
+    let main_fn: ItemFn = parse_macro_input!(input);
+
+    quote! {
+        #main_fn
+
+        #[naked]
+        #[no_mangle]
+        unsafe extern "C" fn _start() -> ! {
+            unsafe fn entry(mem: *mut usize) -> ! {
+                let (argc, argv, envp) = origin::program::compute_args(mem);
+                origin::program::init_runtime(mem, envp);
+                origin::program::exit(main())
+            }
+
+            #[cfg(target_arch = "x86_64")]
+            core::arch::asm!(
+                "mov rdi, rsp", // Pass the incoming `rsp` as the arg to `entry`.
+                "push rbp",     // Set the return address to zero.
+                "jmp {entry}",  // Jump to `entry`.
+                entry = sym entry,
+                options(noreturn),
+            );
+        }
+    }
+    .into()
 }

--- a/macros/src/lib.rs
+++ b/macros/src/lib.rs
@@ -1,14 +1,6 @@
-pub fn add(left: usize, right: usize) -> usize {
-    left + right
-}
+use proc_macro::TokenStream;
 
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn it_works() {
-        let result = add(2, 2);
-        assert_eq!(result, 4);
-    }
+#[proc_macro_attribute]
+pub fn main(_attr: TokenStream, item: TokenStream) -> TokenStream {
+    item
 }

--- a/macros/src/lib.rs
+++ b/macros/src/lib.rs
@@ -1,10 +1,13 @@
 use proc_macro::TokenStream;
+use proc_macro2::TokenStream as TokenStream2;
 use quote::quote;
 use syn::{parse_macro_input, ItemFn};
 
 #[proc_macro_attribute]
 pub fn main(_attr: TokenStream, input: TokenStream) -> TokenStream {
     let main_fn: ItemFn = parse_macro_input!(input);
+    let main_fn_ident = &main_fn.sig.ident;
+    let asm_impl = asm_impl();
 
     quote! {
         #main_fn
@@ -15,18 +18,71 @@ pub fn main(_attr: TokenStream, input: TokenStream) -> TokenStream {
             unsafe fn entry(mem: *mut usize) -> ! {
                 let (argc, argv, envp) = origin::program::compute_args(mem);
                 origin::program::init_runtime(mem, envp);
-                origin::program::exit(main())
+                origin::program::exit(#main_fn_ident())
             }
 
-            #[cfg(target_arch = "x86_64")]
-            core::arch::asm!(
-                "mov rdi, rsp", // Pass the incoming `rsp` as the arg to `entry`.
-                "push rbp",     // Set the return address to zero.
-                "jmp {entry}",  // Jump to `entry`.
-                entry = sym entry,
-                options(noreturn),
-            );
+            #asm_impl
         }
     }
     .into()
+}
+
+/// Provides the asm implementation to start the program
+fn asm_impl() -> TokenStream2 {
+    quote! {
+        // Jump to `entry`, passing it the initial stack pointer value as an
+        // argument, a null return address, a null frame pointer, and an aligned
+        // stack pointer. On many architectures, the incoming frame pointer is
+        // already null.
+
+        #[cfg(target_arch = "x86_64")]
+        core::arch::asm!(
+            "mov rdi, rsp", // Pass the incoming `rsp` as the arg to `entry`.
+            "push rbp",     // Set the return address to zero.
+            "jmp {entry}",  // Jump to `entry`.
+            entry = sym entry,
+            options(noreturn),
+        );
+
+        #[cfg(target_arch = "aarch64")]
+        core::arch::asm!(
+            "mov x0, sp",   // Pass the incoming `sp` as the arg to `entry`.
+            "mov x30, xzr", // Set the return address to zero.
+            "b {entry}",    // Jump to `entry`.
+            entry = sym entry,
+            options(noreturn),
+        );
+
+        #[cfg(target_arch = "arm")]
+        core::arch::asm!(
+            "mov r0, sp\n", // Pass the incoming `sp` as the arg to `entry`.
+            "mov lr, #0",   // Set the return address to zero.
+            "b {entry}",    // Jump to `entry`.
+            entry = sym entry,
+            options(noreturn),
+        );
+
+        #[cfg(target_arch = "riscv64")]
+        core::arch::asm!(
+            "mv a0, sp",    // Pass the incoming `sp` as the arg to `entry`.
+            "mv ra, zero",  // Set the return address to zero.
+            "mv fp, zero",  // Set the frame address to zero.
+            "tail {entry}", // Jump to `entry`.
+            entry = sym entry,
+            options(noreturn),
+        );
+
+        #[cfg(target_arch = "x86")]
+        core::arch::asm!(
+            "mov eax, esp", // Save the incoming `esp` value.
+            "push ebp",     // Pad for alignment.
+            "push ebp",     // Pad for alignment.
+            "push ebp",     // Pad for alignment.
+            "push eax",     // Pass saved the incoming `esp` as the arg to `entry`.
+            "push ebp",     // Set the return address to zero.
+            "jmp {entry}",  // Jump to `entry`.
+            entry = sym entry,
+            options(noreturn),
+        );
+    }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -40,6 +40,10 @@ pub mod thread;
 #[cfg_attr(target_arch = "arm", path = "arch/arm.rs")]
 mod arch;
 
+
+#[cfg(feature = "macros")]
+pub use origin_macros::main;
+
 /// The program entry point.
 ///
 /// # Safety

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,6 +10,9 @@
 #![deny(lossy_provenance_casts)]
 #![no_std]
 
+#![allow(dead_code)] // FIXME: this is just so tests pass while I implement everything
+
+
 #[cfg(all(feature = "alloc", not(feature = "rustc-dep-of-std")))]
 extern crate alloc;
 

--- a/src/program.rs
+++ b/src/program.rs
@@ -79,8 +79,9 @@ pub(super) unsafe extern "C" fn entry(mem: *mut usize) -> ! {
     exit(status)
 }
 
+/// TODO: docs
 #[cfg(any(feature = "origin-start", feature = "external-start"))]
-unsafe fn compute_args(mem: *mut usize) -> (i32, *mut *mut u8, *mut *mut u8) {
+pub unsafe fn compute_args(mem: *mut usize) -> (i32, *mut *mut u8, *mut *mut u8) {
     use linux_raw_sys::ctypes::c_uint;
 
     let argc = *mem as c_int;
@@ -95,9 +96,10 @@ unsafe fn compute_args(mem: *mut usize) -> (i32, *mut *mut u8, *mut *mut u8) {
     (argc, argv, envp)
 }
 
+/// TODO: docs
 #[cfg(any(feature = "origin-start", feature = "external-start"))]
 #[allow(unused_variables)]
-unsafe fn init_runtime(mem: *mut usize, envp: *mut *mut u8) {
+pub unsafe fn init_runtime(mem: *mut usize, envp: *mut *mut u8) {
     // Explicitly initialize `rustix` so that we can control the initialization
     // order.
     #[cfg(feature = "param")]
@@ -114,9 +116,10 @@ unsafe fn init_runtime(mem: *mut usize, envp: *mut *mut u8) {
     initialize_main_thread(mem.cast());
 }
 
+/// TODO: docs
 #[cfg(any(feature = "origin-start", feature = "external-start"))]
 #[allow(unused_variables)]
-unsafe fn call_user_code(argc: c_int, argv: *mut *mut u8, envp: *mut *mut u8) -> i32 {
+pub unsafe fn call_user_code(argc: c_int, argv: *mut *mut u8, envp: *mut *mut u8) -> i32 {
     extern "C" {
         fn main(argc: c_int, argv: *mut *mut u8, envp: *mut *mut u8) -> c_int;
     }
@@ -140,7 +143,7 @@ unsafe fn call_user_code(argc: c_int, argv: *mut *mut u8, envp: *mut *mut u8) ->
 /// Call the constructors in the `.init_array` section.
 #[cfg(any(feature = "origin-start", feature = "external-start"))]
 #[cfg(feature = "init-fini-arrays")]
-unsafe fn call_ctors(argc: c_int, argv: *mut *mut u8, envp: *mut *mut u8) {
+pub unsafe fn call_ctors(argc: c_int, argv: *mut *mut u8, envp: *mut *mut u8) {
     use core::ffi::c_void;
 
     extern "C" {

--- a/src/program.rs
+++ b/src/program.rs
@@ -30,10 +30,6 @@ use rustix_futex_sync::Mutex;
 /// `mem` should point to the stack as provided by the operating system.
 #[cfg(any(feature = "origin-start", feature = "external-start"))]
 pub(super) unsafe extern "C" fn entry(mem: *mut usize) -> ! {
-    extern "C" {
-        fn main(argc: c_int, argv: *mut *mut u8, envp: *mut *mut u8) -> c_int;
-    }
-
     // Do some basic precondition checks, to ensure that our assembly code did
     // what we expect it to do. These are debug-only for now, to keep the
     // release-mode startup code simple to disassemble and inspect, while we're
@@ -74,16 +70,9 @@ pub(super) unsafe extern "C" fn entry(mem: *mut usize) -> ! {
 
     // Compute `argc`, `argv`, and `envp`.
     let (argc, argv, envp) = compute_args(mem);
-    init_runtime(mem, argc, argv, envp);
+    init_runtime(mem, envp);
 
-    #[cfg(feature = "log")]
-    log::trace!("Calling `main({:?}, {:?}, {:?})`", argc, argv, envp);
-
-    // Call `main`.
-    let status = main(argc, argv, envp);
-
-    #[cfg(feature = "log")]
-    log::trace!("`main` returned `{:?}`", status);
+    let status = call_user_code(argc, argv, envp);
 
     // Run functions registered with `at_exit`, and exit with main's return
     // value.
@@ -108,7 +97,7 @@ unsafe fn compute_args(mem: *mut usize) -> (i32, *mut *mut u8, *mut *mut u8) {
 
 #[cfg(any(feature = "origin-start", feature = "external-start"))]
 #[allow(unused_variables)]
-unsafe fn init_runtime(mem: *mut usize, argc: c_int, argv: *mut *mut u8, envp: *mut *mut u8) {
+unsafe fn init_runtime(mem: *mut usize, envp: *mut *mut u8) {
     // Explicitly initialize `rustix` so that we can control the initialization
     // order.
     #[cfg(feature = "param")]
@@ -123,10 +112,29 @@ unsafe fn init_runtime(mem: *mut usize, argc: c_int, argv: *mut *mut u8, envp: *
     // Initialize the main thread.
     #[cfg(feature = "origin-thread")]
     initialize_main_thread(mem.cast());
+}
+
+#[cfg(any(feature = "origin-start", feature = "external-start"))]
+#[allow(unused_variables)]
+unsafe fn call_user_code(argc: c_int, argv: *mut *mut u8, envp: *mut *mut u8) -> i32 {
+    extern "C" {
+        fn main(argc: c_int, argv: *mut *mut u8, envp: *mut *mut u8) -> c_int;
+    }
 
     // Call the functions registered via `.init_array`.
     #[cfg(feature = "init-fini-arrays")]
     call_ctors(argc, argv, envp);
+
+    #[cfg(feature = "log")]
+    log::trace!("Calling `main({:?}, {:?}, {:?})`", argc, argv, envp);
+
+    // Call `main`.
+    let status = main(argc, argv, envp);
+
+    #[cfg(feature = "log")]
+    log::trace!("`main` returned `{:?}`", status);
+
+    status
 }
 
 /// Call the constructors in the `.init_array` section.


### PR DESCRIPTION
This pr is very complex as it attempts to do a bunch of things at once.

- First and foremost it adds an origin-macros crate which a export a single macro called `main` that generates the glue code to start the program
- Tries to remove the existing _start and entry implementations so that user either have to implement them themselves, use the new macro or relay on a wrapper such as `origin-stdio` or `mustang`
- Rework the api to make some item public and allow for the macro to not only work but to not make it a requirement
- Update all the examples/test to the new implementation
- Update all the docs to reflect the new changes

There are still some question that need to be answered mainly:
- Should this completely substitute the old implementation or should they coexist?
- How to coordinate updates to projects that depend on origin?
- How should we handle relocation? The current code is completely broken since it relayed on the hard-coded extern.
- Maybe rethink the scope of origin. Should it really handle all this stuff? Perhaps it could just perform the startup using linux system calls without worrying about libc compatibility and let that be handle by another crate