### PR TITLE
Fix the tiny example on mold, and add notes about linkers and code size.

### DIFF
--- a/example-crates/tiny/build.rs
+++ b/example-crates/tiny/build.rs
@@ -7,8 +7,6 @@ fn main() {
 
     // Tell the linker to exclude the .eh_frame_hdr section.
     println!("cargo:rustc-link-arg=-Wl,--no-eh-frame-hdr");
-    // Tell the linker not to page-align sections.
-    println!("cargo:rustc-link-arg=-Wl,-n");
     // Tell the linker to make the text and data readable and writeable. This
     // allows them to occupy the same page.
     println!("cargo:rustc-link-arg=-Wl,-N");


### PR DESCRIPTION
Mold doesn't support -n, and it doesn't help here anyway, so remove it, though add a note about it in README.md.

And, mold, gold, and lld all seem to produce larger binaries on this tiny example, so mention that in the README.md too.