### PR TITLE
Remove "rustix/param" from the "experimental-relocate" feature.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -96,7 +96,7 @@ init-fini-arrays = []
 
 # Enable highly experimental support for performing startup-time relocations,
 # needed to support statically-linked PIE executables.
-experimental-relocate = ["rustix/mm", "rustix/runtime", "param"]
+experimental-relocate = ["rustix/mm", "rustix/runtime"]
 
 [package.metadata.docs.rs]
 features = ["origin-program", "origin-thread", "origin-signal", "origin-start"]


### PR DESCRIPTION
The experimental-relocate feature no longer uses `rustix::param`; indeed, it can't, since it can't call into code in other crates until after it's done.