### PR TITLE
Reorder the items in src/thread/linux_raw.rs.

### DIFF
--- a/src/thread/linux_raw.rs
+++ b/src/thread/linux_raw.rs
@@ -26,62 +26,115 @@ use {
     rustix::process::{getrlimit, Resource},
 };
 
-/// A numerical thread identifier.
-pub use rustix::thread::Pid as ThreadId;
-
-/// The entrypoint where Rust code is first executed on a new thread.
+/// An opaque pointer to a thread.
 ///
-/// This calls `fn_` on the new thread. When `fn_` returns, the thread exits.
-///
-/// # Safety
-///
-/// After calling `fn_`, this terminates the thread.
-pub(super) unsafe extern "C" fn entry(fn_: *mut Box<dyn FnOnce() -> Option<Box<dyn Any>>>) -> ! {
-    let fn_ = Box::from_raw(fn_);
+/// This type does not detach on drop. It just leaks the thread. To detach or
+/// join, call `detach_thread` or `join_thread` explicitly.
+#[derive(Copy, Clone)]
+pub struct Thread(NonNull<ThreadData>);
 
-    #[cfg(feature = "log")]
-    log::trace!("Thread[{:?}] launched", current_thread_id());
-
-    // Do some basic precondition checks, to ensure that our assembly code did
-    // what we expect it to do. These are debug-only for now, to keep the
-    // release-mode startup code simple to disassemble and inspect, while we're
-    // getting started.
-    #[cfg(debug_assertions)]
-    {
-        extern "C" {
-            #[link_name = "llvm.frameaddress"]
-            fn builtin_frame_address(level: i32) -> *const u8;
-            #[link_name = "llvm.returnaddress"]
-            fn builtin_return_address(level: i32) -> *const u8;
-            #[cfg(target_arch = "aarch64")]
-            #[link_name = "llvm.sponentry"]
-            fn builtin_sponentry() -> *const u8;
-        }
-
-        // Check that the incoming stack pointer is where we expect it to be.
-        debug_assert_eq!(builtin_return_address(0), core::ptr::null());
-        debug_assert_ne!(builtin_frame_address(0), core::ptr::null());
-        #[cfg(not(any(target_arch = "x86", target_arch = "arm")))]
-        debug_assert_eq!(builtin_frame_address(0).addr() & 0xf, 0);
-        #[cfg(target_arch = "arm")]
-        debug_assert_eq!(builtin_frame_address(0).addr() & 0x3, 0);
-        #[cfg(target_arch = "x86")]
-        debug_assert_eq!(builtin_frame_address(0).addr() & 0xf, 8);
-        debug_assert_eq!(builtin_frame_address(1), core::ptr::null());
-        #[cfg(target_arch = "aarch64")]
-        debug_assert_ne!(builtin_sponentry(), core::ptr::null());
-        #[cfg(target_arch = "aarch64")]
-        debug_assert_eq!(builtin_sponentry().addr() & 0xf, 0);
-
-        // Check that `clone` stored our thread id as we expected.
-        debug_assert_eq!(current_thread_id(), gettid());
+impl Thread {
+    /// Convert to `Self` from a raw pointer.
+    #[inline]
+    pub fn from_raw(raw: *mut c_void) -> Self {
+        Self(NonNull::new(raw.cast()).unwrap())
     }
 
-    // Call the user thread function. In `std`, this is `thread_start`. Ignore
-    // the return value for now, as `std` doesn't need it.
-    let _result = fn_();
+    /// Convert to `Self` from a raw non-null pointer.
+    #[inline]
+    pub fn from_raw_non_null(raw: NonNull<c_void>) -> Self {
+        Self(raw.cast())
+    }
 
-    exit_thread()
+    /// Convert to a raw pointer from a `Self`.
+    #[inline]
+    pub fn to_raw(self) -> *mut c_void {
+        self.0.cast().as_ptr()
+    }
+
+    /// Convert to a raw non-null pointer from a `Self`.
+    #[inline]
+    pub fn to_raw_non_null(self) -> NonNull<c_void> {
+        self.0.cast()
+    }
+}
+
+/// Data associated with a thread.
+///
+/// This is not `repr(C)` and not ABI-exposed.
+struct ThreadData {
+    thread_id: AtomicI32,
+    detached: AtomicU8,
+    stack_addr: *mut c_void,
+    stack_size: usize,
+    guard_size: usize,
+    map_size: usize,
+    dtors: Vec<Box<dyn FnOnce()>>,
+}
+
+// Values for `ThreadData::detached`.
+const INITIAL: u8 = 0;
+const DETACHED: u8 = 1;
+const ABANDONED: u8 = 2;
+
+impl ThreadData {
+    #[inline]
+    fn new(
+        tid: Option<ThreadId>,
+        stack_addr: *mut c_void,
+        stack_size: usize,
+        guard_size: usize,
+        map_size: usize,
+    ) -> Self {
+        Self {
+            thread_id: AtomicI32::new(ThreadId::as_raw(tid)),
+            detached: AtomicU8::new(INITIAL),
+            stack_addr,
+            stack_size,
+            guard_size,
+            map_size,
+            dtors: Vec::new(),
+        }
+    }
+}
+
+/// Metadata describing a thread.
+#[repr(C)]
+struct Metadata {
+    /// Crate-internal fields. On platforms where TLS data goes after the
+    /// ABI-exposed fields, we store our fields before them.
+    #[cfg(any(target_arch = "aarch64", target_arch = "arm", target_arch = "riscv64"))]
+    thread: ThreadData,
+
+    /// ABI-exposed fields. This is allocated at a platform-specific offset
+    /// from the platform thread-pointer register value.
+    abi: Abi,
+
+    /// Crate-internal fields. On platforms where TLS data goes before the
+    /// ABI-exposed fields, we store our fields after them.
+    #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+    thread: ThreadData,
+}
+
+/// Fields which accessed by user code via known offsets from the platform
+/// thread-pointer register.
+#[repr(C)]
+#[cfg_attr(target_arch = "arm", repr(align(8)))]
+struct Abi {
+    /// Aarch64 has an ABI-exposed `dtv` field (though we don't yet implement
+    /// dynamic linking).
+    #[cfg(any(target_arch = "aarch64", target_arch = "arm"))]
+    dtv: *const c_void,
+
+    /// x86 and x86-64 put a copy of the thread-pointer register at the memory
+    /// location pointed to by the thread-pointer register, because reading the
+    /// thread-pointer register directly is slow.
+    #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+    this: *mut Abi,
+
+    /// Padding to put the TLS data which follows at its known offset.
+    #[cfg(any(target_arch = "aarch64", target_arch = "arm"))]
+    pad: [usize; 1],
 }
 
 /// Information obtained from the `DT_TLS` segment of the executable.
@@ -95,10 +148,9 @@ static mut STARTUP_TLS_INFO: StartupTlsInfo = StartupTlsInfo {
     align: 0,
 };
 
-/// The requested minimum size for stacks.
-static mut STARTUP_STACK_SIZE: usize = 0;
-
 /// The type of [`STARTUP_TLS_INFO`].
+///
+/// This is not `repr(C)` and not ABI-exposed.
 struct StartupTlsInfo {
     /// The base address of the TLS segment. Once initialize, this is
     /// always non-null, even when the TLS data is absent, so that the
@@ -112,6 +164,9 @@ struct StartupTlsInfo {
     /// The required alignment for the TLS segment.
     align: usize,
 }
+
+/// The requested minimum size for stacks.
+static mut STARTUP_STACK_SIZE: usize = 0;
 
 /// Initialize `STARTUP_TLS_INFO` and `STARTUP_STACK_SIZE`.
 ///
@@ -130,8 +185,10 @@ pub(super) fn initialize_startup_thread_info() {
     // the `PT_DYNAMIC` header's static address, if present.
     let dynamic_addr: *const c_void = unsafe { &_DYNAMIC };
 
-    // SAFETY: We assume the phdr array pointer and length the kernel provided
-    // to the process describe a valid phdr array.
+    // SAFETY: We assume that the phdr array pointer and length the kernel
+    // provided to the process describe a valid phdr array, and that there are
+    // no other threads running so we can store to `STARTUP_TLS_INFO` and
+    // `STARTUP_STACK_SIZE` without synchronization.
     unsafe {
         let phdrs_end = current_phdr.cast::<u8>().add(phnum * phent).cast();
         while current_phdr != phdrs_end {
@@ -185,318 +242,8 @@ extern "C" {
 // Rust has `extern_weak` but it isn't stable, so use a `global_asm`.
 core::arch::global_asm!(".weak _DYNAMIC");
 
-/// Metadata describing a thread.
-#[repr(C)]
-struct Metadata {
-    /// Crate-internal fields. On platforms where TLS data goes after the
-    /// ABI-exposed fields, we store our fields before them.
-    #[cfg(any(target_arch = "aarch64", target_arch = "arm", target_arch = "riscv64"))]
-    thread: ThreadData,
-
-    /// ABI-exposed fields. This is allocated at a platform-specific offset
-    /// from the platform thread-pointer register value.
-    abi: Abi,
-
-    /// Crate-internal fields. On platforms where TLS data goes before the
-    /// ABI-exposed fields, we store our fields after them.
-    #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
-    thread: ThreadData,
-}
-
-/// Fields which accessed by user code via known offsets from the platform
-/// thread-pointer register.
-#[repr(C)]
-#[cfg_attr(target_arch = "arm", repr(align(8)))]
-struct Abi {
-    /// Aarch64 has an ABI-exposed `dtv` field (though we don't yet implement
-    /// dynamic linking).
-    #[cfg(any(target_arch = "aarch64", target_arch = "arm"))]
-    dtv: *const c_void,
-
-    /// x86 and x86-64 put a copy of the thread-pointer register at the memory
-    /// location pointed to by the thread-pointer register, because reading the
-    /// thread-pointer register directly is slow.
-    #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
-    this: *mut Abi,
-
-    /// Padding to put the TLS data which follows at its known offset.
-    #[cfg(any(target_arch = "aarch64", target_arch = "arm"))]
-    pad: [usize; 1],
-}
-
-/// An opaque pointer to a thread.
-///
-/// This type does not detach on drop. It just leaks the thread. To detach or
-/// join, call `detach_thread` or `join_thread` explicitly.
-#[derive(Copy, Clone)]
-pub struct Thread(NonNull<ThreadData>);
-
-impl Thread {
-    /// Convert to `Self` from a raw pointer.
-    #[inline]
-    pub fn from_raw(raw: *mut c_void) -> Self {
-        Self(NonNull::new(raw.cast()).unwrap())
-    }
-
-    /// Convert to `Self` from a raw non-null pointer.
-    #[inline]
-    pub fn from_raw_non_null(raw: NonNull<c_void>) -> Self {
-        Self(raw.cast())
-    }
-
-    /// Convert to a raw pointer from a `Self`.
-    #[inline]
-    pub fn to_raw(self) -> *mut c_void {
-        self.0.cast().as_ptr()
-    }
-
-    /// Convert to a raw non-null pointer from a `Self`.
-    #[inline]
-    pub fn to_raw_non_null(self) -> NonNull<c_void> {
-        self.0.cast()
-    }
-}
-
-/// Data associated with a thread. This is not `repr(C)` and not ABI-exposed.
-struct ThreadData {
-    thread_id: AtomicI32,
-    detached: AtomicU8,
-    stack_addr: *mut c_void,
-    stack_size: usize,
-    guard_size: usize,
-    map_size: usize,
-    dtors: Vec<Box<dyn FnOnce()>>,
-}
-
-// Values for `ThreadData::detached`.
-const INITIAL: u8 = 0;
-const DETACHED: u8 = 1;
-const ABANDONED: u8 = 2;
-
-impl ThreadData {
-    #[inline]
-    fn new(
-        tid: Option<ThreadId>,
-        stack_addr: *mut c_void,
-        stack_size: usize,
-        guard_size: usize,
-        map_size: usize,
-    ) -> Self {
-        Self {
-            thread_id: AtomicI32::new(ThreadId::as_raw(tid)),
-            detached: AtomicU8::new(INITIAL),
-            stack_addr,
-            stack_size,
-            guard_size,
-            map_size,
-            dtors: Vec::new(),
-        }
-    }
-}
-
-#[inline]
-#[must_use]
-fn current_metadata() -> *mut Metadata {
-    get_thread_pointer()
-        .cast::<u8>()
-        .wrapping_sub(offset_of!(Metadata, abi))
-        .cast()
-}
-
-/// Return a raw pointer to the data associated with the current thread.
-#[inline]
-#[must_use]
-pub fn current_thread() -> Thread {
-    unsafe { Thread(NonNull::from(&mut (*current_metadata()).thread)) }
-}
-
-/// Return the current thread id.
-///
-/// This is the same as [`rustix::thread::gettid`], but loads the value from a
-/// field in the runtime rather than making a system call.
-#[inline]
-#[must_use]
-pub fn current_thread_id() -> ThreadId {
-    let tid = thread_id(current_thread());
-    debug_assert_eq!(tid, gettid(), "`current_thread_id` disagrees with `gettid`");
-    tid
-}
-
-/// Set the current thread id, after a `fork`.
-///
-/// The only valid use for this is in the implementation of libc-like `fork`
-/// wrappers such as the one in c-scape. `posix_spawn`-like uses of `fork`
-/// don't need to do this because they shouldn't do anything that cares about
-/// the thread id before doing their `execve`.
-///
-/// # Safety
-///
-/// This must only be called immediately after a `fork` before any other
-/// threads are created. `tid` must be the same value as what [`gettid`] would
-/// return.
-#[cfg(feature = "set_thread_id")]
-#[cfg_attr(doc_cfg, doc(cfg(feature = "set_thread_id")))]
-#[doc(hidden)]
-#[inline]
-pub unsafe fn set_current_thread_id_after_a_fork(tid: ThreadId) {
-    assert_ne!(
-        tid.as_raw_nonzero().get(),
-        current_thread().0.as_ref().thread_id.load(SeqCst),
-        "current thread ID already matches new thread ID"
-    );
-    assert_eq!(tid, gettid(), "new thread ID disagrees with `gettid`");
-    current_thread()
-        .0
-        .as_ref()
-        .thread_id
-        .store(tid.as_raw_nonzero().get(), SeqCst);
-}
-
-/// Return the TLS entry for the current thread.
-#[inline]
-#[must_use]
-pub fn current_thread_tls_addr(offset: usize) -> *mut c_void {
-    // Platforms where TLS data goes after the ABI-exposed fields.
-    #[cfg(any(target_arch = "aarch64", target_arch = "arm", target_arch = "riscv64"))]
-    {
-        crate::arch::get_thread_pointer()
-            .cast::<u8>()
-            .wrapping_add(TLS_OFFSET)
-            .wrapping_add(size_of::<Abi>())
-            .wrapping_add(offset)
-            .cast()
-    }
-
-    // Platforms where TLS data goes before the ABI-exposed fields.
-    #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
-    unsafe {
-        get_thread_pointer()
-            .cast::<u8>()
-            .wrapping_add(TLS_OFFSET)
-            .wrapping_sub(STARTUP_TLS_INFO.mem_size)
-            .wrapping_add(offset)
-            .cast()
-    }
-}
-
-/// Return the id of a thread.
-///
-/// This is the same as [`rustix::thread::gettid`], but loads the value from a
-/// field in the runtime rather than making a system call.
-///
-/// # Safety
-///
-/// `thread` must point to a valid and live thread record.
-#[inline]
-pub fn thread_id(thread: Thread) -> ThreadId {
-    let raw = unsafe { thread.0.as_ref().thread_id.load(SeqCst) };
-    debug_assert!(raw > 0);
-    unsafe { ThreadId::from_raw_unchecked(raw) }
-}
-
-/// Return the current thread's stack address (lowest address), size, and guard
-/// size.
-///
-/// # Safety
-///
-/// `thread` must point to a valid and live thread record.
-#[inline]
-#[must_use]
-pub unsafe fn thread_stack(thread: Thread) -> (*mut c_void, usize, usize) {
-    let data = thread.0.as_ref();
-    (data.stack_addr, data.stack_size, data.guard_size)
-}
-
-/// Registers a function to call when the current thread exits.
-pub fn at_thread_exit(func: Box<dyn FnOnce()>) {
-    // Safety: `current_thread()` points to thread-local data which is valid
-    // as long as the thread is alive.
-    unsafe {
-        current_thread().0.as_mut().dtors.push(func);
-    }
-}
-
-/// Call the destructors registered with [`at_thread_exit`].
-pub(crate) fn call_thread_dtors(current: Thread) {
-    let mut current = current;
-
-    // Run the `dtors`, in reverse order of registration. Note that destructors
-    // may register new destructors.
-    //
-    // Safety: `current` points to thread-local data which is valid as long
-    // as the thread is alive.
-    while let Some(func) = unsafe { current.0.as_mut().dtors.pop() } {
-        #[cfg(feature = "log")]
-        if log::log_enabled!(log::Level::Trace) {
-            log::trace!(
-                "Thread[{:?}] calling `at_thread_exit`-registered function",
-                unsafe { current.0.as_ref().thread_id.load(SeqCst) },
-            );
-        }
-
-        func();
-    }
-}
-
-/// Call the destructors registered with [`at_thread_exit`] and exit the
-/// thread.
-unsafe fn exit_thread() -> ! {
-    let current = current_thread();
-
-    // Call functions registered with `at_thread_exit`.
-    call_thread_dtors(current);
-
-    // Read the thread's state, and set it to `ABANDONED` if it was `INITIAL`,
-    // which tells `join_thread` to free the memory. Otherwise, it's in the
-    // `DETACHED` state, and we free the memory immediately.
-    let state = current
-        .0
-        .as_ref()
-        .detached
-        .compare_exchange(INITIAL, ABANDONED, SeqCst, SeqCst);
-    if let Err(e) = state {
-        // The thread was detached. Prepare to free the memory. First read out
-        // all the fields that we'll need before freeing it.
-        #[cfg(feature = "log")]
-        let current_thread_id = current.0.as_ref().thread_id.load(SeqCst);
-        let current_map_size = current.0.as_ref().map_size;
-        let current_stack_addr = current.0.as_ref().stack_addr;
-        let current_guard_size = current.0.as_ref().guard_size;
-
-        #[cfg(feature = "log")]
-        log::trace!("Thread[{:?}] exiting as detached", current_thread_id);
-        debug_assert_eq!(e, DETACHED);
-
-        // Deallocate the `ThreadData`.
-        drop_in_place(current.0.as_ptr());
-
-        // Free the thread's `mmap` region, if we allocated it.
-        let map_size = current_map_size;
-        if map_size != 0 {
-            // Null out the tid address so that the kernel doesn't write to
-            // memory that we've freed trying to clear our tid when we exit.
-            let _ = set_tid_address(null_mut());
-
-            // `munmap` the memory, which also frees the stack we're currently
-            // on, and do an `exit` carefully without touching the stack.
-            let map = current_stack_addr.cast::<u8>().sub(current_guard_size);
-            munmap_and_exit_thread(map.cast(), map_size);
-        }
-    } else {
-        // The thread was not detached, so its memory will be freed when it's
-        // joined.
-        #[cfg(feature = "log")]
-        if log::log_enabled!(log::Level::Trace) {
-            log::trace!(
-                "Thread[{:?}] exiting as joinable",
-                current.0.as_ref().thread_id.load(SeqCst)
-            );
-        }
-    }
-
-    // Terminate the thread.
-    rustix::runtime::exit_thread(0)
-}
+/// A numerical thread identifier.
+pub use rustix::thread::Pid as ThreadId;
 
 /// Initialize the main thread.
 ///
@@ -632,7 +379,7 @@ pub fn create_thread(
     stack_size: usize,
     guard_size: usize,
 ) -> io::Result<Thread> {
-    // Safety: `STARTUP_TLS_INFO` is initialized at program startup before
+    // SAFETY: `STARTUP_TLS_INFO` is initialized at program startup before
     // we come here creating new threads.
     let (startup_tls_align, startup_tls_mem_size) =
         unsafe { (STARTUP_TLS_INFO.align, STARTUP_TLS_INFO.mem_size) };
@@ -808,8 +555,143 @@ pub fn create_thread(
     }
 }
 
-fn round_up(addr: usize, boundary: usize) -> usize {
-    (addr + (boundary - 1)) & boundary.wrapping_neg()
+/// The entrypoint where Rust code is first executed on a new thread.
+///
+/// This calls `fn_` on the new thread. When `fn_` returns, the thread exits.
+///
+/// # Safety
+///
+/// `fn_` must be valid to call [`Box::from_raw`] on.
+///
+/// After calling `fn_`, this terminates the thread.
+pub(super) unsafe extern "C" fn entry(fn_: *mut Box<dyn FnOnce() -> Option<Box<dyn Any>>>) -> ! {
+    let fn_ = Box::from_raw(fn_);
+
+    #[cfg(feature = "log")]
+    log::trace!("Thread[{:?}] launched", current_thread_id());
+
+    // Do some basic precondition checks, to ensure that our assembly code did
+    // what we expect it to do. These are debug-only for now, to keep the
+    // release-mode startup code simple to disassemble and inspect, while we're
+    // getting started.
+    #[cfg(debug_assertions)]
+    {
+        extern "C" {
+            #[link_name = "llvm.frameaddress"]
+            fn builtin_frame_address(level: i32) -> *const u8;
+            #[link_name = "llvm.returnaddress"]
+            fn builtin_return_address(level: i32) -> *const u8;
+            #[cfg(target_arch = "aarch64")]
+            #[link_name = "llvm.sponentry"]
+            fn builtin_sponentry() -> *const u8;
+        }
+
+        // Check that the incoming stack pointer is where we expect it to be.
+        debug_assert_eq!(builtin_return_address(0), core::ptr::null());
+        debug_assert_ne!(builtin_frame_address(0), core::ptr::null());
+        #[cfg(not(any(target_arch = "x86", target_arch = "arm")))]
+        debug_assert_eq!(builtin_frame_address(0).addr() & 0xf, 0);
+        #[cfg(target_arch = "arm")]
+        debug_assert_eq!(builtin_frame_address(0).addr() & 0x3, 0);
+        #[cfg(target_arch = "x86")]
+        debug_assert_eq!(builtin_frame_address(0).addr() & 0xf, 8);
+        debug_assert_eq!(builtin_frame_address(1), core::ptr::null());
+        #[cfg(target_arch = "aarch64")]
+        debug_assert_ne!(builtin_sponentry(), core::ptr::null());
+        #[cfg(target_arch = "aarch64")]
+        debug_assert_eq!(builtin_sponentry().addr() & 0xf, 0);
+
+        // Check that `clone` stored our thread id as we expected.
+        debug_assert_eq!(current_thread_id(), gettid());
+    }
+
+    // Call the user thread function. In `std`, this is `thread_start`. Ignore
+    // the return value for now, as `std` doesn't need it.
+    let _result = fn_();
+
+    exit_thread()
+}
+
+/// Call the destructors registered with [`at_thread_exit`] and exit the
+/// thread.
+unsafe fn exit_thread() -> ! {
+    let current = current_thread();
+
+    // Call functions registered with `at_thread_exit`.
+    call_thread_dtors(current);
+
+    // Read the thread's state, and set it to `ABANDONED` if it was `INITIAL`,
+    // which tells `join_thread` to free the memory. Otherwise, it's in the
+    // `DETACHED` state, and we free the memory immediately.
+    let state = current
+        .0
+        .as_ref()
+        .detached
+        .compare_exchange(INITIAL, ABANDONED, SeqCst, SeqCst);
+    if let Err(e) = state {
+        // The thread was detached. Prepare to free the memory. First read out
+        // all the fields that we'll need before freeing it.
+        #[cfg(feature = "log")]
+        let current_thread_id = current.0.as_ref().thread_id.load(SeqCst);
+        let current_map_size = current.0.as_ref().map_size;
+        let current_stack_addr = current.0.as_ref().stack_addr;
+        let current_guard_size = current.0.as_ref().guard_size;
+
+        #[cfg(feature = "log")]
+        log::trace!("Thread[{:?}] exiting as detached", current_thread_id);
+        debug_assert_eq!(e, DETACHED);
+
+        // Deallocate the `ThreadData`.
+        drop_in_place(current.0.as_ptr());
+
+        // Free the thread's `mmap` region, if we allocated it.
+        let map_size = current_map_size;
+        if map_size != 0 {
+            // Null out the tid address so that the kernel doesn't write to
+            // memory that we've freed trying to clear our tid when we exit.
+            let _ = set_tid_address(null_mut());
+
+            // `munmap` the memory, which also frees the stack we're currently
+            // on, and do an `exit` carefully without touching the stack.
+            let map = current_stack_addr.cast::<u8>().sub(current_guard_size);
+            munmap_and_exit_thread(map.cast(), map_size);
+        }
+    } else {
+        // The thread was not detached, so its memory will be freed when it's
+        // joined.
+        #[cfg(feature = "log")]
+        if log::log_enabled!(log::Level::Trace) {
+            log::trace!(
+                "Thread[{:?}] exiting as joinable",
+                current.0.as_ref().thread_id.load(SeqCst)
+            );
+        }
+    }
+
+    // Terminate the thread.
+    rustix::runtime::exit_thread(0)
+}
+
+/// Call the destructors registered with [`at_thread_exit`].
+pub(crate) fn call_thread_dtors(current: Thread) {
+    let mut current = current;
+
+    // Run the `dtors`, in reverse order of registration. Note that destructors
+    // may register new destructors.
+    //
+    // SAFETY: `current` points to thread-local data which is valid as long
+    // as the thread is alive.
+    while let Some(func) = unsafe { current.0.as_mut().dtors.pop() } {
+        #[cfg(feature = "log")]
+        if log::log_enabled!(log::Level::Trace) {
+            log::trace!(
+                "Thread[{:?}] calling `at_thread_exit`-registered function",
+                unsafe { current.0.as_ref().thread_id.load(SeqCst) },
+            );
+        }
+
+        func();
+    }
 }
 
 /// Marks a thread as "detached".
@@ -903,7 +785,7 @@ unsafe fn wait_for_thread_exit(thread: Thread) {
 }
 
 #[cfg(feature = "log")]
-unsafe fn log_thread_to_be_freed(thread_id: i32) {
+fn log_thread_to_be_freed(thread_id: i32) {
     if log::log_enabled!(log::Level::Trace) {
         log::trace!("Thread[{:?}] memory being freed", thread_id);
     }
@@ -926,6 +808,130 @@ unsafe fn free_thread_memory(thread: Thread) {
         let map = stack_addr.cast::<u8>().sub(guard_size);
         munmap(map.cast(), map_size).unwrap();
     }
+}
+
+/// Registers a function to call when the current thread exits.
+pub fn at_thread_exit(func: Box<dyn FnOnce()>) {
+    // SAFETY: `current_thread()` points to thread-local data which is valid
+    // as long as the thread is alive.
+    unsafe {
+        current_thread().0.as_mut().dtors.push(func);
+    }
+}
+
+#[inline]
+#[must_use]
+fn current_metadata() -> *mut Metadata {
+    get_thread_pointer()
+        .cast::<u8>()
+        .wrapping_sub(offset_of!(Metadata, abi))
+        .cast()
+}
+
+/// Return a raw pointer to the data associated with the current thread.
+#[inline]
+#[must_use]
+pub fn current_thread() -> Thread {
+    // SAFETY: This is only called after we've initialized all the thread
+    // state.
+    unsafe { Thread(NonNull::from(&mut (*current_metadata()).thread)) }
+}
+
+/// Return the current thread id.
+///
+/// This is the same as [`rustix::thread::gettid`], but loads the value from a
+/// field in the runtime rather than making a system call.
+#[inline]
+#[must_use]
+pub fn current_thread_id() -> ThreadId {
+    let tid = thread_id(current_thread());
+    debug_assert_eq!(tid, gettid(), "`current_thread_id` disagrees with `gettid`");
+    tid
+}
+
+/// Set the current thread id, after a `fork`.
+///
+/// The only valid use for this is in the implementation of libc-like `fork`
+/// wrappers such as the one in c-scape. `posix_spawn`-like uses of `fork`
+/// don't need to do this because they shouldn't do anything that cares about
+/// the thread id before doing their `execve`.
+///
+/// # Safety
+///
+/// This must only be called immediately after a `fork` before any other
+/// threads are created. `tid` must be the same value as what [`gettid`] would
+/// return.
+#[cfg(feature = "set_thread_id")]
+#[cfg_attr(doc_cfg, doc(cfg(feature = "set_thread_id")))]
+#[doc(hidden)]
+#[inline]
+pub unsafe fn set_current_thread_id_after_a_fork(tid: ThreadId) {
+    assert_ne!(
+        tid.as_raw_nonzero().get(),
+        current_thread().0.as_ref().thread_id.load(SeqCst),
+        "current thread ID already matches new thread ID"
+    );
+    assert_eq!(tid, gettid(), "new thread ID disagrees with `gettid`");
+    current_thread()
+        .0
+        .as_ref()
+        .thread_id
+        .store(tid.as_raw_nonzero().get(), SeqCst);
+}
+
+/// Return the TLS entry for the current thread.
+#[inline]
+#[must_use]
+pub fn current_thread_tls_addr(offset: usize) -> *mut c_void {
+    // Platforms where TLS data goes after the ABI-exposed fields.
+    #[cfg(any(target_arch = "aarch64", target_arch = "arm", target_arch = "riscv64"))]
+    {
+        crate::arch::get_thread_pointer()
+            .cast::<u8>()
+            .wrapping_add(TLS_OFFSET)
+            .wrapping_add(size_of::<Abi>())
+            .wrapping_add(offset)
+            .cast()
+    }
+
+    // Platforms where TLS data goes before the ABI-exposed fields.
+    #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+    unsafe {
+        get_thread_pointer()
+            .cast::<u8>()
+            .wrapping_add(TLS_OFFSET)
+            .wrapping_sub(STARTUP_TLS_INFO.mem_size)
+            .wrapping_add(offset)
+            .cast()
+    }
+}
+
+/// Return the id of a thread.
+///
+/// This is the same as [`rustix::thread::gettid`], but loads the value from a
+/// field in the runtime rather than making a system call.
+///
+/// # Safety
+///
+/// `thread` must point to a valid and live thread record.
+#[inline]
+pub fn thread_id(thread: Thread) -> ThreadId {
+    let raw = unsafe { thread.0.as_ref().thread_id.load(SeqCst) };
+    debug_assert!(raw > 0);
+    unsafe { ThreadId::from_raw_unchecked(raw) }
+}
+
+/// Return the current thread's stack address (lowest address), size, and guard
+/// size.
+///
+/// # Safety
+///
+/// `thread` must point to a valid and live thread record.
+#[inline]
+#[must_use]
+pub unsafe fn thread_stack(thread: Thread) -> (*mut c_void, usize, usize) {
+    let data = thread.0.as_ref();
+    (data.stack_addr, data.stack_size, data.guard_size)
 }
 
 /// Return the default stack size for new threads.
@@ -955,6 +961,10 @@ pub fn yield_current_thread() {
 #[no_mangle]
 unsafe extern "C" fn __aeabi_read_tp() -> *mut c_void {
     get_thread_pointer()
+}
+
+fn round_up(addr: usize, boundary: usize) -> usize {
+    (addr + (boundary - 1)) & boundary.wrapping_neg()
 }
 
 // We define `clone` and `CloneFlags` here in `origin` instead of `rustix`


### PR DESCRIPTION
This grouping puts all the major types together, all the initialization code together, and all the main API functions together.