### PR TITLE
Move the `_start` function into `src/arch/*`.

### DIFF
--- a/example-crates/external-start/src/main.rs
+++ b/example-crates/external-start/src/main.rs
@@ -50,7 +50,7 @@ static EARLY_INIT_ARRAY: unsafe extern "C" fn(i32, *mut *mut u8) = {
         // Compute the initial stack address provided by the kernel.
         let mem = argv.sub(1);
 
-        origin::start(mem as _);
+        origin::program::start(mem as _);
     }
     function
 };

--- a/src/arch/aarch64.rs
+++ b/src/arch/aarch64.rs
@@ -1,4 +1,3 @@
-#[cfg(any(feature = "origin-thread", feature = "origin-signal"))]
 use core::arch::asm;
 #[cfg(feature = "origin-signal")]
 use linux_raw_sys::general::__NR_rt_sigreturn;
@@ -11,7 +10,35 @@ use {
     rustix::thread::RawPid,
 };
 
+/// The program entry point.
+///
+/// # Safety
+///
+/// This function must never be called explicitly. It is the first thing
+/// executed in the program, and it assumes that memory is laid out according
+/// to the operating system convention for starting a new program.
+#[cfg(all(feature = "origin-program", feature = "origin-start"))]
+#[naked]
+#[no_mangle]
+pub(super) unsafe extern "C" fn _start() -> ! {
+    // Jump to `entry`, passing it the initial stack pointer value as an
+    // argument, a null return address, a null frame pointer, and an aligned
+    // stack pointer. On many architectures, the incoming frame pointer is
+    // already null.
+    asm!(
+        "mov x0, sp",   // Pass the incoming `sp` as the arg to `entry`.
+        "mov x30, xzr", // Set the return address to zero.
+        "b {entry}",    // Jump to `entry`.
+        entry = sym super::program::entry,
+        options(noreturn),
+    )
+}
+
 /// A wrapper around the Linux `clone` system call.
+///
+/// This can't be implemented in `rustix` because the child starts executing at
+/// the same point as the parent and we need to use inline asm to have the
+/// child jump to our new-thread entrypoint.
 #[cfg(feature = "origin-thread")]
 #[inline]
 pub(super) unsafe fn clone(

--- a/src/arch/arm.rs
+++ b/src/arch/arm.rs
@@ -1,4 +1,3 @@
-#[cfg(any(feature = "origin-thread", feature = "origin-signal"))]
 use core::arch::asm;
 #[cfg(feature = "origin-signal")]
 use linux_raw_sys::general::{__NR_rt_sigreturn, __NR_sigreturn};
@@ -11,7 +10,35 @@ use {
     rustix::thread::RawPid,
 };
 
+/// The program entry point.
+///
+/// # Safety
+///
+/// This function must never be called explicitly. It is the first thing
+/// executed in the program, and it assumes that memory is laid out according
+/// to the operating system convention for starting a new program.
+#[cfg(all(feature = "origin-program", feature = "origin-start"))]
+#[naked]
+#[no_mangle]
+pub(super) unsafe extern "C" fn _start() -> ! {
+    // Jump to `entry`, passing it the initial stack pointer value as an
+    // argument, a null return address, a null frame pointer, and an aligned
+    // stack pointer. On many architectures, the incoming frame pointer is
+    // already null.
+    asm!(
+        "mov r0, sp\n", // Pass the incoming `sp` as the arg to `entry`.
+        "mov lr, #0",   // Set the return address to zero.
+        "b {entry}",    // Jump to `entry`.
+        entry = sym super::program::entry,
+        options(noreturn),
+    )
+}
+
 /// A wrapper around the Linux `clone` system call.
+///
+/// This can't be implemented in `rustix` because the child starts executing at
+/// the same point as the parent and we need to use inline asm to have the
+/// child jump to our new-thread entrypoint.
 #[cfg(feature = "origin-thread")]
 #[inline]
 pub(super) unsafe fn clone(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,13 +1,13 @@
 #![doc = include_str!("../README.md")]
 #![deny(missing_docs)]
+#![cfg_attr(debug_assertions, allow(internal_features))]
 #![cfg_attr(doc_cfg, feature(doc_cfg))]
 #![feature(asm_const)]
 #![feature(naked_functions)]
-#![feature(link_llvm_intrinsics)]
+#![cfg_attr(debug_assertions, feature(link_llvm_intrinsics))]
 #![cfg_attr(feature = "experimental-relocate", feature(cfg_relocation_model))]
 #![feature(strict_provenance)]
-#![deny(fuzzy_provenance_casts)]
-#![deny(lossy_provenance_casts)]
+#![deny(fuzzy_provenance_casts, lossy_provenance_casts)]
 #![no_std]
 
 #[cfg(all(feature = "alloc", not(feature = "rustc-dep-of-std")))]
@@ -20,6 +20,20 @@ extern crate unwinding;
 #[cfg(target_arch = "arm")]
 mod unwind_unimplemented;
 
+#[cfg(any(
+    feature = "origin-thread",
+    feature = "origin-signal",
+    all(feature = "origin-program", feature = "origin-start")
+))]
+#[cfg_attr(target_arch = "aarch64", path = "arch/aarch64.rs")]
+#[cfg_attr(target_arch = "x86_64", path = "arch/x86_64.rs")]
+#[cfg_attr(target_arch = "x86", path = "arch/x86.rs")]
+#[cfg_attr(target_arch = "riscv64", path = "arch/riscv64.rs")]
+#[cfg_attr(target_arch = "arm", path = "arch/arm.rs")]
+mod arch;
+#[cfg(feature = "log")]
+mod log;
+
 pub mod program;
 #[cfg(feature = "signal")]
 #[cfg_attr(doc_cfg, doc(cfg(feature = "signal")))]
@@ -31,121 +45,3 @@ pub mod signal;
 #[cfg_attr(feature = "origin-thread", path = "thread/linux_raw.rs")]
 #[cfg_attr(not(feature = "origin-thread"), path = "thread/libc.rs")]
 pub mod thread;
-
-#[cfg(any(feature = "origin-thread", feature = "origin-signal"))]
-#[cfg_attr(target_arch = "aarch64", path = "arch/aarch64.rs")]
-#[cfg_attr(target_arch = "x86_64", path = "arch/x86_64.rs")]
-#[cfg_attr(target_arch = "x86", path = "arch/x86.rs")]
-#[cfg_attr(target_arch = "riscv64", path = "arch/riscv64.rs")]
-#[cfg_attr(target_arch = "arm", path = "arch/arm.rs")]
-mod arch;
-
-/// The program entry point.
-///
-/// # Safety
-///
-/// This function should never be called explicitly. It is the first thing
-/// executed in the program, and it assumes that memory is laid out according
-/// to the operating system convention for starting a new program.
-#[cfg(feature = "origin-program")]
-#[cfg(feature = "origin-start")]
-#[naked]
-#[no_mangle]
-unsafe extern "C" fn _start() -> ! {
-    use core::arch::asm;
-    use program::entry;
-
-    // Jump to `entry`, passing it the initial stack pointer value as an
-    // argument, a null return address, a null frame pointer, and an aligned
-    // stack pointer. On many architectures, the incoming frame pointer is
-    // already null.
-
-    #[cfg(target_arch = "x86_64")]
-    asm!(
-        "mov rdi, rsp", // Pass the incoming `rsp` as the arg to `entry`.
-        "push rbp",     // Set the return address to zero.
-        "jmp {entry}",  // Jump to `entry`.
-        entry = sym entry,
-        options(noreturn),
-    );
-
-    #[cfg(target_arch = "aarch64")]
-    asm!(
-        "mov x0, sp",   // Pass the incoming `sp` as the arg to `entry`.
-        "mov x30, xzr", // Set the return address to zero.
-        "b {entry}",    // Jump to `entry`.
-        entry = sym entry,
-        options(noreturn),
-    );
-
-    #[cfg(target_arch = "arm")]
-    asm!(
-        "mov r0, sp\n", // Pass the incoming `sp` as the arg to `entry`.
-        "mov lr, #0",   // Set the return address to zero.
-        "b {entry}",    // Jump to `entry`.
-        entry = sym entry,
-        options(noreturn),
-    );
-
-    #[cfg(target_arch = "riscv64")]
-    asm!(
-        "mv a0, sp",    // Pass the incoming `sp` as the arg to `entry`.
-        "mv ra, zero",  // Set the return address to zero.
-        "mv fp, zero",  // Set the frame address to zero.
-        "tail {entry}", // Jump to `entry`.
-        entry = sym entry,
-        options(noreturn),
-    );
-
-    #[cfg(target_arch = "x86")]
-    asm!(
-        "mov eax, esp", // Save the incoming `esp` value.
-        "push ebp",     // Pad for stack pointer alignment.
-        "push ebp",     // Pad for stack pointer alignment.
-        "push ebp",     // Pad for stack pointer alignment.
-        "push eax",     // Pass saved the incoming `esp` as the arg to `entry`.
-        "push ebp",     // Set the return address to zero.
-        "jmp {entry}",  // Jump to `entry`.
-        entry = sym entry,
-        options(noreturn),
-    );
-}
-
-/// A program entry point similar to `_start`, but which is meant to be called
-/// by something else in the program rather than the OS.
-///
-/// # Safety
-///
-/// `mem` must point to a stack with the contents that the OS would provide
-/// on the initial stack.
-#[cfg(feature = "origin-program")]
-#[cfg(feature = "external-start")]
-pub unsafe fn start(mem: *mut usize) -> ! {
-    program::entry(mem)
-}
-
-/// Initialize logging, if enabled.
-#[cfg(feature = "log")]
-#[link_section = ".init_array.00099"]
-#[used]
-static INIT_ARRAY: unsafe extern "C" fn() = {
-    unsafe extern "C" fn function() {
-        #[cfg(feature = "atomic-dbg")]
-        atomic_dbg::log::init();
-        #[cfg(feature = "env_logger")]
-        env_logger::init();
-
-        log::trace!(target: "origin::program", "Program started");
-
-        // Log the thread id. We initialized the main earlier than this, but
-        // we couldn't initialize the logger until after the main thread is
-        // intialized :-).
-        #[cfg(feature = "origin-thread")]
-        log::trace!(
-            target: "origin::thread",
-            "Main Thread[{:?}] initialized",
-            thread::current_thread_id().as_raw_nonzero()
-        );
-    }
-    function
-};

--- a/src/log.rs
+++ b/src/log.rs
@@ -1,0 +1,27 @@
+/// Initialize logging, if enabled.
+#[link_section = ".init_array.00099"]
+#[used]
+static INIT_ARRAY: unsafe extern "C" fn() = {
+    unsafe extern "C" fn function() {
+        // Initialize the chosen logger.
+        #[cfg(feature = "atomic-dbg")]
+        atomic_dbg::log::init();
+        #[cfg(feature = "env_logger")]
+        env_logger::init();
+
+        // Log the first message, announcing that it is us that started the
+        // process. We started the program earlier than this, but we couldn't
+        // initialize the logger until we initialized the main thread.
+        log::trace!(target: "origin::program", "Program started");
+
+        // Log the main thread id. Similarly, we initialized the main thread
+        // earlier than this, but we couldn't log until now.
+        #[cfg(feature = "origin-thread")]
+        log::trace!(
+            target: "origin::thread",
+            "Main Thread[{:?}] initialized",
+            thread::current_thread_id().as_raw_nonzero()
+        );
+    }
+    function
+};

--- a/src/program.rs
+++ b/src/program.rs
@@ -97,6 +97,19 @@ pub(super) unsafe extern "C" fn entry(mem: *mut usize) -> ! {
     exit(status)
 }
 
+/// A program entry point similar to `_start`, but which is meant to be called
+/// by something else in the program rather than the OS.
+///
+/// # Safety
+///
+/// `mem` must point to a stack with the contents that the OS would provide
+/// on the initial stack.
+#[cfg(feature = "origin-program")]
+#[cfg(feature = "external-start")]
+pub unsafe fn start(mem: *mut usize) -> ! {
+    entry(mem)
+}
+
 /// Compute `argc`, `argv`, and `envp`.
 ///
 /// # Safety
@@ -433,7 +446,7 @@ unsafe fn relocate(envp: *mut *mut u8) {
     // the optimizer won't have any idea what we're up to.
     struct StaticStart(*const u8);
     unsafe impl Sync for StaticStart {}
-    static STATIC_START: StaticStart = StaticStart(crate::_start as *const u8);
+    static STATIC_START: StaticStart = StaticStart(crate::arch::_start as *const u8);
     let mut static_start_addr: *const *const u8 = &STATIC_START.0;
     asm!("# {}", inout(reg) static_start_addr);
     let mut static_start = (*static_start_addr).addr();


### PR DESCRIPTION
All the other inline asm blocks are in `src/arch/*`, so for consistency move the `_start` function definition into `src/arch/*` too.

Also move the log initialization function into its own file.

After this, src/lib.rs doesn't have any significant code in it, which makes it easier to see how the crate is organized.