### PR TITLE
Refactor cargo features and logging.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,10 +21,15 @@ memoffset = { version = "0.9.0", optional = true }
 log = { version = "0.4.14", default-features = false, optional = true }
 rustix-futex-sync = "0.1.0"
 
-# Optional logging backends. You can use any external logger, but using these
-# features allows origin to initialize the logger before main, so that you can
-# see the log messages emitted before main is called.
+# Optional logging backends for use with "origin-program". You can use any
+# external logger, but using these features allows origin to initialize the
+# logger before `origin_main`, so that you can see the log messages emitted
+# before `origin_main` is called.
+
+# Enable `env_logger`; eg. recognizing `RUST_LOG=trace`. This requires `std`.
 env_logger = { version = "0.10.0", optional = true, default-features = false }
+
+# Enable `atomic-dbg`'s simple logger. This doesn't require `std`.
 atomic-dbg = { version = "0.1", default-features = false, optional = true, features = ["log"] }
 
 # Enable this when disabling origin's implementations.
@@ -65,12 +70,12 @@ origin-thread = ["memoffset", "rustix/runtime", "origin-program", "thread"]
 origin-signal = ["rustix/runtime", "signal"]
 
 # Use origin's `_start` definition.
-origin-start = ["rustix/use-explicitly-provided-auxv", "rustix/runtime"]
+origin-start = ["rustix/use-explicitly-provided-auxv", "rustix/runtime", "origin-program"]
 
 # Don't use origin's `_start` definition, but export a `start` function which
 # is meant to be run very early in program startup and passed a pointer to
 # the initial stack. Don't enable this when enabling "origin-start".
-external-start = ["rustix/use-explicitly-provided-auxv", "rustix/runtime"]
+external-start = ["rustix/use-explicitly-provided-auxv", "rustix/runtime", "origin-program"]
 
 # Disable logging.
 max_level_off = ["log/max_level_off"]
@@ -99,5 +104,5 @@ init-fini-arrays = []
 experimental-relocate = ["rustix/mm", "rustix/runtime"]
 
 [package.metadata.docs.rs]
-features = ["origin-program", "origin-thread", "origin-signal", "origin-start"]
+features = ["origin-thread", "origin-signal", "origin-start"]
 rustdoc-args = ["--cfg", "doc_cfg"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -77,6 +77,10 @@ origin-start = ["rustix/use-explicitly-provided-auxv", "rustix/runtime", "origin
 # the initial stack. Don't enable this when enabling "origin-start".
 external-start = ["rustix/use-explicitly-provided-auxv", "rustix/runtime", "origin-program"]
 
+# The loggers depend on a `.init_array` entry to initialize themselves.
+atomic-dbg = ["dep:atomic-dbg", "init-fini-arrays"]
+env_logger = ["dep:env_logger", "init-fini-arrays"]
+
 # Disable logging.
 max_level_off = ["log/max_level_off"]
 

--- a/example-crates/external-start/Cargo.toml
+++ b/example-crates/external-start/Cargo.toml
@@ -7,7 +7,7 @@ publish = false
 [dependencies]
 # Origin can be depended on just like any other crate. For no_std, disable
 # the default features, and the desired features.
-origin = { path = "../..", default-features = false, features = ["origin-program", "origin-thread", "external-start"] }
+origin = { path = "../..", default-features = false, features = ["origin-thread", "external-start"] }
 
 # Ensure that libc gets linked.
 libc = { version = "0.2", default-features = false }

--- a/example-crates/origin-start-lto/Cargo.toml
+++ b/example-crates/origin-start-lto/Cargo.toml
@@ -7,7 +7,7 @@ publish = false
 [dependencies]
 # Origin can be depended on just like any other crate. For no_std, disable
 # the default features, and the desired features.
-origin = { path = "../..", default-features = false, features = ["origin-program", "origin-thread", "origin-start"] }
+origin = { path = "../..", default-features = false, features = ["origin-thread", "origin-start"] }
 
 # Crates to help writing no_std code.
 atomic-dbg = { version = "0.1.8", default-features = false }

--- a/example-crates/origin-start-no-alloc/Cargo.toml
+++ b/example-crates/origin-start-no-alloc/Cargo.toml
@@ -7,7 +7,7 @@ publish = false
 [dependencies]
 # Origin can be depended on just like any other crate. For no_std, disable
 # the default features, and the desired features.
-origin = { path = "../..", default-features = false, features = ["origin-program", "origin-start"] }
+origin = { path = "../..", default-features = false, features = ["origin-start"] }
 
 # Crates to help writing no_std code.
 atomic-dbg = { version = "0.1.8", default-features = false }

--- a/example-crates/origin-start/Cargo.toml
+++ b/example-crates/origin-start/Cargo.toml
@@ -7,7 +7,7 @@ publish = false
 [dependencies]
 # Origin can be depended on just like any other crate. For no_std, disable
 # the default features, and the desired features.
-origin = { path = "../..", default-features = false, features = ["origin-program", "origin-thread", "origin-start"] }
+origin = { path = "../..", default-features = false, features = ["origin-thread", "origin-start"] }
 
 # Crates to help writing no_std code.
 atomic-dbg = { version = "0.1.8", default-features = false }

--- a/example-crates/tiny/Cargo.toml
+++ b/example-crates/tiny/Cargo.toml
@@ -7,7 +7,7 @@ publish = false
 [dependencies]
 # Origin can be depended on just like any other crate. For no_std, disable
 # the default features, and add the desired features.
-origin = { path = "../..", default-features = false, features = ["origin-program", "origin-start"] }
+origin = { path = "../..", default-features = false, features = ["origin-start"] }
 
 # Crates to help writing no_std code.
 compiler_builtins = { version = "0.1.101", features = ["mem"] }

--- a/example-crates/tiny/README.md
+++ b/example-crates/tiny/README.md
@@ -26,7 +26,7 @@ things that our simple example doesn't need. We only enable the features
 needed for our minimal test program:
 
 ```toml
-origin = { path = "../..", default-features = false, features = ["origin-program", "origin-start"] }
+origin = { path = "../..", default-features = false, features = ["origin-start"] }
 ```
 
 Then, we add a `#[profile.release]` section to our Cargo.toml, to enable
@@ -50,9 +50,9 @@ In detail:
 LTO is Link-Time Optimization, which gives the optimizer the ability to see the
 whole program at once, and be more aggressive about deleting unneeded code.
 
-For example, in our test program, it enables inlining of the `main` function
-into the code in `origin` that calls it. Since it's just returning the constant
-`42`, inlining reduces code size.
+For example, in our test program, it enables inlining of the `origin_main`
+function into the code in `origin` that calls it. Since it's just returning the
+constant `42`, inlining reduces code size.
 
 > `panic = "abort"`
 
@@ -193,7 +193,7 @@ With all these optimizations, the generated code looks like this:
 
 Those first 3 instructions are origin's `_start` function. The next 5
 instructions are `origin::program::entry` and everything, including the user
-`main` function and the `exit_group` syscall inlined into it.
+`origin_main` function and the `exit_group` syscall inlined into it.
 
 ## Optimizations not done
 

--- a/src/arch/aarch64.rs
+++ b/src/arch/aarch64.rs
@@ -17,7 +17,7 @@ use {
 /// This function must never be called explicitly. It is the first thing
 /// executed in the program, and it assumes that memory is laid out according
 /// to the operating system convention for starting a new program.
-#[cfg(all(feature = "origin-program", feature = "origin-start"))]
+#[cfg(feature = "origin-start")]
 #[naked]
 #[no_mangle]
 pub(super) unsafe extern "C" fn _start() -> ! {
@@ -77,10 +77,7 @@ pub(super) unsafe fn clone(
 }
 
 /// Write a value to the platform thread-pointer register.
-#[cfg(all(
-    feature = "origin-thread",
-    any(feature = "origin-start", feature = "external-start")
-))]
+#[cfg(feature = "origin-thread")]
 #[inline]
 pub(super) unsafe fn set_thread_pointer(ptr: *mut c_void) {
     asm!("msr tpidr_el0,{}", in(reg) ptr);
@@ -88,10 +85,7 @@ pub(super) unsafe fn set_thread_pointer(ptr: *mut c_void) {
 }
 
 /// Read the value of the platform thread-pointer register.
-#[cfg(all(
-    feature = "origin-thread",
-    any(feature = "origin-start", feature = "external-start")
-))]
+#[cfg(feature = "origin-thread")]
 #[inline]
 pub(super) fn get_thread_pointer() -> *mut c_void {
     let ptr;

--- a/src/arch/arm.rs
+++ b/src/arch/arm.rs
@@ -17,7 +17,7 @@ use {
 /// This function must never be called explicitly. It is the first thing
 /// executed in the program, and it assumes that memory is laid out according
 /// to the operating system convention for starting a new program.
-#[cfg(all(feature = "origin-program", feature = "origin-start"))]
+#[cfg(feature = "origin-start")]
 #[naked]
 #[no_mangle]
 pub(super) unsafe extern "C" fn _start() -> ! {
@@ -78,10 +78,7 @@ pub(super) unsafe fn clone(
 }
 
 /// Write a value to the platform thread-pointer register.
-#[cfg(all(
-    feature = "origin-thread",
-    any(feature = "origin-start", feature = "external-start")
-))]
+#[cfg(feature = "origin-thread")]
 #[inline]
 pub(super) unsafe fn set_thread_pointer(ptr: *mut c_void) {
     rustix::runtime::arm_set_tls(ptr).expect("arm_set_tls");
@@ -89,10 +86,7 @@ pub(super) unsafe fn set_thread_pointer(ptr: *mut c_void) {
 }
 
 /// Read the value of the platform thread-pointer register.
-#[cfg(all(
-    feature = "origin-thread",
-    any(feature = "origin-start", feature = "external-start")
-))]
+#[cfg(feature = "origin-thread")]
 #[inline]
 pub(super) fn get_thread_pointer() -> *mut c_void {
     let ptr;

--- a/src/arch/riscv64.rs
+++ b/src/arch/riscv64.rs
@@ -1,7 +1,4 @@
-#[cfg(any(
-    feature = "origin-thread",
-    all(feature = "origin-program", feature = "origin-start")
-))]
+#[cfg(any(feature = "origin-thread", feature = "origin-start"))]
 use core::arch::asm;
 #[cfg(feature = "origin-thread")]
 use {
@@ -19,7 +16,7 @@ use {
 /// This function must never be called explicitly. It is the first thing
 /// executed in the program, and it assumes that memory is laid out according
 /// to the operating system convention for starting a new program.
-#[cfg(all(feature = "origin-program", feature = "origin-start"))]
+#[cfg(feature = "origin-start")]
 #[naked]
 #[no_mangle]
 pub(super) unsafe extern "C" fn _start() -> ! {
@@ -80,10 +77,7 @@ pub(super) unsafe fn clone(
 }
 
 /// Write a value to the platform thread-pointer register.
-#[cfg(all(
-    feature = "origin-thread",
-    any(feature = "origin-start", feature = "external-start")
-))]
+#[cfg(feature = "origin-thread")]
 #[inline]
 pub(super) unsafe fn set_thread_pointer(ptr: *mut c_void) {
     asm!("mv tp,{}", in(reg) ptr);
@@ -91,10 +85,7 @@ pub(super) unsafe fn set_thread_pointer(ptr: *mut c_void) {
 }
 
 /// Read the value of the platform thread-pointer register.
-#[cfg(all(
-    feature = "origin-thread",
-    any(feature = "origin-start", feature = "external-start")
-))]
+#[cfg(feature = "origin-thread")]
 #[inline]
 pub(super) fn get_thread_pointer() -> *mut c_void {
     let ptr;

--- a/src/arch/x86.rs
+++ b/src/arch/x86.rs
@@ -18,7 +18,7 @@ use {
 /// This function must never be called explicitly. It is the first thing
 /// executed in the program, and it assumes that memory is laid out according
 /// to the operating system convention for starting a new program.
-#[cfg(all(feature = "origin-program", feature = "origin-start"))]
+#[cfg(feature = "origin-start")]
 #[naked]
 #[no_mangle]
 pub(super) unsafe extern "C" fn _start() -> ! {
@@ -116,10 +116,7 @@ pub(super) unsafe fn clone(
 }
 
 /// Write a value to the platform thread-pointer register.
-#[cfg(all(
-    feature = "origin-thread",
-    any(feature = "origin-start", feature = "external-start")
-))]
+#[cfg(feature = "origin-thread")]
 #[inline]
 pub(super) unsafe fn set_thread_pointer(ptr: *mut c_void) {
     let mut user_desc = rustix::runtime::UserDesc {
@@ -143,10 +140,7 @@ pub(super) unsafe fn set_thread_pointer(ptr: *mut c_void) {
 }
 
 /// Read the value of the platform thread-pointer register.
-#[cfg(all(
-    feature = "origin-thread",
-    any(feature = "origin-start", feature = "external-start")
-))]
+#[cfg(feature = "origin-thread")]
 #[inline]
 pub(super) fn get_thread_pointer() -> *mut c_void {
     let ptr;

--- a/src/arch/x86_64.rs
+++ b/src/arch/x86_64.rs
@@ -18,7 +18,7 @@ use {
 /// This function must never be called explicitly. It is the first thing
 /// executed in the program, and it assumes that memory is laid out according
 /// to the operating system convention for starting a new program.
-#[cfg(all(feature = "origin-program", feature = "origin-start"))]
+#[cfg(feature = "origin-start")]
 #[naked]
 #[no_mangle]
 pub(super) unsafe extern "C" fn _start() -> ! {
@@ -81,10 +81,7 @@ pub(super) unsafe fn clone(
 }
 
 /// Write a value to the platform thread-pointer register.
-#[cfg(all(
-    feature = "origin-thread",
-    any(feature = "origin-start", feature = "external-start")
-))]
+#[cfg(feature = "origin-thread")]
 #[inline]
 pub(super) unsafe fn set_thread_pointer(ptr: *mut c_void) {
     rustix::runtime::set_fs(ptr);
@@ -93,10 +90,7 @@ pub(super) unsafe fn set_thread_pointer(ptr: *mut c_void) {
 }
 
 /// Read the value of the platform thread-pointer register.
-#[cfg(all(
-    feature = "origin-thread",
-    any(feature = "origin-start", feature = "external-start")
-))]
+#[cfg(feature = "origin-thread")]
 #[inline]
 pub(super) fn get_thread_pointer() -> *mut c_void {
     let ptr;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23,7 +23,7 @@ mod unwind_unimplemented;
 #[cfg(any(
     feature = "origin-thread",
     feature = "origin-signal",
-    all(feature = "origin-program", feature = "origin-start")
+    feature = "origin-start"
 ))]
 #[cfg_attr(target_arch = "aarch64", path = "arch/aarch64.rs")]
 #[cfg_attr(target_arch = "x86_64", path = "arch/x86_64.rs")]
@@ -31,7 +31,7 @@ mod unwind_unimplemented;
 #[cfg_attr(target_arch = "riscv64", path = "arch/riscv64.rs")]
 #[cfg_attr(target_arch = "arm", path = "arch/arm.rs")]
 mod arch;
-#[cfg(feature = "log")]
+#[cfg(all(feature = "origin-program", feature = "log"))]
 mod log;
 
 pub mod program;

--- a/src/log.rs
+++ b/src/log.rs
@@ -1,27 +1,22 @@
-/// Initialize logging, if enabled.
-#[link_section = ".init_array.00099"]
-#[used]
-static INIT_ARRAY: unsafe extern "C" fn() = {
-    unsafe extern "C" fn function() {
-        // Initialize the chosen logger.
-        #[cfg(feature = "atomic-dbg")]
-        atomic_dbg::log::init();
-        #[cfg(feature = "env_logger")]
-        env_logger::init();
+pub(crate) fn init() {
+    // Initialize the chosen logger.
+    #[cfg(feature = "atomic-dbg")]
+    atomic_dbg::log::init();
+    #[cfg(feature = "env_logger")]
+    env_logger::init();
 
-        // Log the first message, announcing that it is us that started the
-        // process. We started the program earlier than this, but we couldn't
-        // initialize the logger until we initialized the main thread.
-        log::trace!(target: "origin::program", "Program started");
+    // Log the first message, announcing that it is us that started the
+    // process. We started the program earlier than this, but we couldn't
+    // initialize the logger until we initialized the main thread.
+    #[cfg(feature = "origin-program")]
+    log::trace!(target: "origin::program", "Program started");
 
-        // Log the main thread id. Similarly, we initialized the main thread
-        // earlier than this, but we couldn't log until now.
-        #[cfg(feature = "origin-thread")]
-        log::trace!(
-            target: "origin::thread",
-            "Main Thread[{:?}] initialized",
-            thread::current_thread_id().as_raw_nonzero()
-        );
-    }
-    function
-};
+    // Log the main thread id. Similarly, we initialized the main thread
+    // earlier than this, but we couldn't log until now.
+    #[cfg(feature = "origin-thread")]
+    log::trace!(
+        target: "origin::thread",
+        "Main Thread[{:?}] initialized",
+        crate::thread::current_thread_id().as_raw_nonzero()
+    );
+}

--- a/src/log.rs
+++ b/src/log.rs
@@ -1,4 +1,18 @@
-pub(crate) fn init() {
+/// Initialize logging, if enabled.
+///
+/// c-scape initializes its environment-variable state at
+/// `.init_array.00098`, so using `.00099` means we run after that, so
+/// initializing loggers that depend on eg. `RUST_LOG` work.
+#[link_section = ".init_array.00099"]
+#[used]
+static INIT_ARRAY: unsafe extern "C" fn() = {
+    unsafe extern "C" fn function() {
+        init()
+    }
+    function
+};
+
+fn init() {
     // Initialize the chosen logger.
     #[cfg(feature = "atomic-dbg")]
     atomic_dbg::log::init();

--- a/src/program.rs
+++ b/src/program.rs
@@ -200,10 +200,6 @@ unsafe fn init_runtime(mem: *mut usize, envp: *mut *mut u8) {
     // Initialize the main thread.
     #[cfg(feature = "origin-thread")]
     initialize_main_thread(mem.cast());
-
-    // Initialize logging.
-    #[cfg(feature = "log")]
-    crate::log::init();
 }
 
 /// Functions registered with [`at_exit`].

--- a/src/program.rs
+++ b/src/program.rs
@@ -27,18 +27,12 @@
 use crate::thread::{initialize_main_thread, initialize_startup_thread_info};
 #[cfg(feature = "alloc")]
 use alloc::boxed::Box;
-#[cfg(all(
-    feature = "alloc",
-    any(feature = "origin-start", feature = "external-start")
-))]
+#[cfg(all(feature = "alloc", feature = "origin-program"))]
 use alloc::vec::Vec;
-#[cfg(not(any(feature = "origin-start", feature = "external-start")))]
+#[cfg(not(feature = "origin-program"))]
 use core::ptr::null_mut;
 use linux_raw_sys::ctypes::c_int;
-#[cfg(all(
-    feature = "alloc",
-    any(feature = "origin-start", feature = "external-start")
-))]
+#[cfg(all(feature = "alloc", feature = "origin-program"))]
 use rustix_futex_sync::Mutex;
 
 /// The entrypoint where Rust code is first executed when the program starts.
@@ -46,7 +40,7 @@ use rustix_futex_sync::Mutex;
 /// # Safety
 ///
 /// `mem` must point to the stack as provided by the operating system.
-#[cfg(any(feature = "origin-start", feature = "external-start"))]
+#[cfg(feature = "origin-program")]
 pub(super) unsafe extern "C" fn entry(mem: *mut usize) -> ! {
     // Do some basic precondition checks, to ensure that our assembly code did
     // what we expect it to do. These are debug-only for now, to keep the
@@ -90,11 +84,60 @@ pub(super) unsafe extern "C" fn entry(mem: *mut usize) -> ! {
     let (argc, argv, envp) = compute_args(mem);
     init_runtime(mem, envp);
 
-    let status = call_user_code(argc, argv, envp);
+    // Call the functions registered via `.init_array`.
+    #[cfg(feature = "init-fini-arrays")]
+    {
+        use core::arch::asm;
+        use core::ffi::c_void;
 
-    // Run functions registered with `at_exit`, and exit with main's return
-    // value.
-    exit(status)
+        extern "C" {
+            static __init_array_start: c_void;
+            static __init_array_end: c_void;
+        }
+
+        // Call the `.init_array` functions. As GLIBC does, pass argc, argv,
+        // and envp as extra arguments. In addition to GLIBC ABI compatibility,
+        // c-scape relies on this.
+        type InitFn = fn(c_int, *mut *mut u8, *mut *mut u8);
+        let mut init = &__init_array_start as *const _ as *const InitFn;
+        let init_end = &__init_array_end as *const _ as *const InitFn;
+        // Prevent the optimizer from optimizing the `!=` comparison to true;
+        // `init` and `init_start` may have the same address.
+        asm!("# {}", inout(reg) init, options(pure, nomem, nostack, preserves_flags));
+
+        while init != init_end {
+            #[cfg(feature = "log")]
+            log::trace!(
+                "Calling `.init_array`-registered function `{:?}({:?}, {:?}, {:?})`",
+                *init,
+                argc,
+                argv,
+                envp
+            );
+            (*init)(argc, argv, envp);
+            init = init.add(1);
+        }
+    }
+
+    {
+        // Declare `origin_main` as documented in [`crate::program`].
+        extern "Rust" {
+            fn origin_main(argc: usize, argv: *mut *mut u8, envp: *mut *mut u8) -> i32;
+        }
+
+        #[cfg(feature = "log")]
+        log::trace!("Calling `origin_main({:?}, {:?}, {:?})`", argc, argv, envp);
+
+        // Call `origin_main`.
+        let status = origin_main(argc as usize, argv, envp);
+
+        #[cfg(feature = "log")]
+        log::trace!("`origin_main` returned `{:?}`", status);
+
+        // Run functions registered with `at_exit`, and exit with
+        // `origin_main`'s return value.
+        exit(status)
+    }
 }
 
 /// A program entry point similar to `_start`, but which is meant to be called
@@ -104,7 +147,6 @@ pub(super) unsafe extern "C" fn entry(mem: *mut usize) -> ! {
 ///
 /// `mem` must point to a stack with the contents that the OS would provide
 /// on the initial stack.
-#[cfg(feature = "origin-program")]
 #[cfg(feature = "external-start")]
 pub unsafe fn start(mem: *mut usize) -> ! {
     entry(mem)
@@ -115,7 +157,7 @@ pub unsafe fn start(mem: *mut usize) -> ! {
 /// # Safety
 ///
 /// `mem` must point to the stack as provided by the operating system.
-#[cfg(any(feature = "origin-start", feature = "external-start"))]
+#[cfg(feature = "origin-program")]
 unsafe fn compute_args(mem: *mut usize) -> (i32, *mut *mut u8, *mut *mut u8) {
     use linux_raw_sys::ctypes::c_uint;
 
@@ -138,7 +180,7 @@ unsafe fn compute_args(mem: *mut usize) -> (i32, *mut *mut u8, *mut *mut u8) {
 ///
 /// `mem` must point to the stack as provided by the operating system. `envp`
 /// must point to the incoming environment variables.
-#[cfg(any(feature = "origin-start", feature = "external-start"))]
+#[cfg(feature = "origin-program")]
 #[allow(unused_variables)]
 unsafe fn init_runtime(mem: *mut usize, envp: *mut *mut u8) {
     // Before doing anything else, perform dynamic relocations.
@@ -158,90 +200,14 @@ unsafe fn init_runtime(mem: *mut usize, envp: *mut *mut u8) {
     // Initialize the main thread.
     #[cfg(feature = "origin-thread")]
     initialize_main_thread(mem.cast());
-}
 
-/// Call user-defined constructors and the `origin_main` function.
-///
-/// Return the status value returned by `origin_main`.
-///
-/// # Safety
-///
-/// `argv` and `envp` must point to the incoming arguments and environment
-/// variables.
-///
-/// All `origin` and `rustix` runtime state must be initialized.
-#[cfg(any(feature = "origin-start", feature = "external-start"))]
-#[allow(clippy::let_and_return)]
-unsafe fn call_user_code(argc: c_int, argv: *mut *mut u8, envp: *mut *mut u8) -> i32 {
-    // Declare `origin_main` as documented in [`crate::program`].
-    extern "Rust" {
-        fn origin_main(argc: usize, argv: *mut *mut u8, envp: *mut *mut u8) -> i32;
-    }
-
-    // Call the functions registered via `.init_array`.
-    #[cfg(feature = "init-fini-arrays")]
-    call_ctors(argc, argv, envp);
-
+    // Initialize logging.
     #[cfg(feature = "log")]
-    log::trace!("Calling `origin_main({:?}, {:?}, {:?})`", argc, argv, envp);
-
-    // Call `origin_main`.
-    let status = origin_main(argc as usize, argv, envp);
-
-    #[cfg(feature = "log")]
-    log::trace!("`origin_main` returned `{:?}`", status);
-
-    status
-}
-
-/// Call user-defined constructors.
-///
-/// # Safety
-///
-/// `argv` and `envp` must point to the incoming arguments and environment
-/// variables.
-///
-/// All `origin` and `rustix` runtime state must be initialized.
-#[cfg(any(feature = "origin-start", feature = "external-start"))]
-#[cfg(feature = "init-fini-arrays")]
-unsafe fn call_ctors(argc: c_int, argv: *mut *mut u8, envp: *mut *mut u8) {
-    use core::arch::asm;
-    use core::ffi::c_void;
-
-    extern "C" {
-        static __init_array_start: c_void;
-        static __init_array_end: c_void;
-    }
-
-    // Call the `.init_array` functions. As GLIBC, does, pass argc, argv,
-    // and envp as extra arguments. In addition to GLIBC ABI compatibility,
-    // c-scape relies on this.
-    type InitFn = fn(c_int, *mut *mut u8, *mut *mut u8);
-    let mut init = &__init_array_start as *const _ as *const InitFn;
-    let init_end = &__init_array_end as *const _ as *const InitFn;
-    // Prevent the optimizer from optimizing the `!=` comparison to true;
-    // `init` and `init_start` may have the same address.
-    asm!("# {}", inout(reg) init, options(pure, nomem, nostack, preserves_flags));
-
-    while init != init_end {
-        #[cfg(feature = "log")]
-        log::trace!(
-            "Calling `.init_array`-registered function `{:?}({:?}, {:?}, {:?})`",
-            *init,
-            argc,
-            argv,
-            envp
-        );
-        (*init)(argc, argv, envp);
-        init = init.add(1);
-    }
+    crate::log::init();
 }
 
 /// Functions registered with [`at_exit`].
-#[cfg(all(
-    feature = "alloc",
-    any(feature = "origin-start", feature = "external-start")
-))]
+#[cfg(all(feature = "alloc", feature = "origin-program"))]
 static DTORS: Mutex<Vec<Box<dyn FnOnce() + Send>>> = Mutex::new(Vec::new());
 
 /// Register a function to be called when [`exit`] is called.
@@ -252,13 +218,13 @@ static DTORS: Mutex<Vec<Box<dyn FnOnce() + Send>>> = Mutex::new(Vec::new());
 /// exits.
 #[cfg(feature = "alloc")]
 pub fn at_exit(func: Box<dyn FnOnce() + Send>) {
-    #[cfg(any(feature = "origin-start", feature = "external-start"))]
+    #[cfg(feature = "origin-program")]
     {
         let mut funcs = DTORS.lock();
         funcs.push(func);
     }
 
-    #[cfg(not(any(feature = "origin-start", feature = "external-start")))]
+    #[cfg(not(feature = "origin-program"))]
     {
         use core::ffi::c_void;
 
@@ -286,19 +252,13 @@ pub fn at_exit(func: Box<dyn FnOnce() + Send>) {
 /// `.fini_array` section, and exit the program.
 pub fn exit(status: c_int) -> ! {
     // Call functions registered with `at_thread_exit`.
-    #[cfg(all(
-        feature = "thread",
-        any(feature = "origin-start", feature = "external-start")
-    ))]
+    #[cfg(all(feature = "thread", feature = "origin-program"))]
     crate::thread::call_thread_dtors(crate::thread::current_thread());
 
     // Call all the registered functions, in reverse order. Leave `DTORS`
     // unlocked while making the call so that functions can add more functions
     // to the end of the list.
-    #[cfg(all(
-        feature = "alloc",
-        any(feature = "origin-start", feature = "external-start")
-    ))]
+    #[cfg(all(feature = "alloc", feature = "origin-program"))]
     loop {
         let mut dtors = DTORS.lock();
         if let Some(dtor) = dtors.pop() {
@@ -312,8 +272,7 @@ pub fn exit(status: c_int) -> ! {
     }
 
     // Call the `.fini_array` functions, in reverse order.
-    #[cfg(any(feature = "origin-start", feature = "external-start"))]
-    #[cfg(feature = "init-fini-arrays")]
+    #[cfg(all(feature = "init-fini-arrays", feature = "origin-program"))]
     unsafe {
         use core::arch::asm;
         use core::ffi::c_void;
@@ -340,13 +299,13 @@ pub fn exit(status: c_int) -> ! {
         }
     }
 
-    #[cfg(any(feature = "origin-start", feature = "external-start"))]
+    #[cfg(feature = "origin-program")]
     {
         // Call `exit_immediately` to exit the program.
         exit_immediately(status)
     }
 
-    #[cfg(not(any(feature = "origin-start", feature = "external-start")))]
+    #[cfg(not(feature = "origin-program"))]
     unsafe {
         // Call `libc` to run *its* dtors, and exit the program.
         libc::exit(status)
@@ -357,16 +316,16 @@ pub fn exit(status: c_int) -> ! {
 /// with the `.fini_array` section.
 #[inline]
 pub fn exit_immediately(status: c_int) -> ! {
-    #[cfg(feature = "log")]
-    log::trace!("Program exiting");
-
-    #[cfg(any(feature = "origin-start", feature = "external-start"))]
+    #[cfg(feature = "origin-program")]
     {
+        #[cfg(feature = "log")]
+        log::trace!("Program exiting with status {:?}", status);
+
         // Call `rustix` to exit the program.
         rustix::runtime::exit_group(status)
     }
 
-    #[cfg(not(any(feature = "origin-start", feature = "external-start")))]
+    #[cfg(not(feature = "origin-program"))]
     unsafe {
         // Call `libc` to exit the program.
         libc::_exit(status)


### PR DESCRIPTION
Make "origin-start" and "external-start" imply "origin-program", as they effectively relied on it anyway, and this simplifies a lot of Cargo.toml examples and `cfg` code.

And, don't enable logging when `origin-program` is not enabled, as origin doesn't have any log messages if it isn't in charge.