### PR TITLE
Improve `rustc-dep-of-std` mode.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ include = ["src", "Cargo.toml", "COPYRIGHT", "LICENSE*", "/*.md"]
 [dependencies]
 linux-raw-sys = { version = "0.4.7", default-features = false, features = ["general", "no_std", "elf"] }
 rustix = { version = "0.38.13", default-features = false }
-bitflags = "2.4.0"
+bitflags = { version = "2.4.0", default-features = false }
 memoffset = { version = "0.9.0", optional = true }
 log = { version = "0.4.14", default-features = false, optional = true }
 rustix-futex-sync = "0.1.0"
@@ -39,6 +39,7 @@ errno = { version = "0.3.3", default-features = false, optional = true }
 # Special dependencies used in rustc-dep-of-std mode.
 core = { version = "1.0.0", optional = true, package = "rustc-std-workspace-core" }
 alloc = { version = "1.0.0", optional = true, package = "rustc-std-workspace-alloc" }
+compiler_builtins = { version = "0.1.101", optional = true }
 
 [target.'cfg(not(target_arch = "arm"))'.dependencies.unwinding]
 version = "0.2.0"
@@ -49,15 +50,19 @@ features = [ "unwinder" ]
 assert_cmd = "2.0.12"
 
 [features]
-default = ["std", "log", "libc", "thread", "init-fini-arrays"]
-std = ["rustix/std"]
+default = ["std", "log", "libc", "errno", "thread", "init-fini-arrays"]
+std = ["rustix/std", "bitflags/std"]
 set_thread_id = []
 rustc-dep-of-std = [
     "dep:core",
     "dep:alloc",
     "linux-raw-sys/rustc-dep-of-std",
     "bitflags/rustc-dep-of-std",
-    "libc/rustc-dep-of-std",
+    "rustix/rustc-dep-of-std",
+    "unwinding/rustc-dep-of-std",
+    "libc?/rustc-dep-of-std",
+    "rustix-futex-sync/rustc-dep-of-std",
+    "dep:compiler_builtins",
 ]
 
 # Use origin's implementation of program startup and shutdown.


### PR DESCRIPTION
In `rustc-dep-of-std` mode, enable the `rustc-dep-of-std` feature on all of origin's dependencies.