### PR TITLE
Rename `get_thread_pointer` to `thread_pointer`.

### DIFF
--- a/src/arch/aarch64.rs
+++ b/src/arch/aarch64.rs
@@ -178,13 +178,13 @@ pub(super) unsafe fn clone(
 #[inline]
 pub(super) unsafe fn set_thread_pointer(ptr: *mut c_void) {
     asm!("msr tpidr_el0, {}", in(reg) ptr);
-    debug_assert_eq!(get_thread_pointer(), ptr);
+    debug_assert_eq!(thread_pointer(), ptr);
 }
 
 /// Read the value of the platform thread-pointer register.
 #[cfg(feature = "origin-thread")]
 #[inline]
-pub(super) fn get_thread_pointer() -> *mut c_void {
+pub(super) fn thread_pointer() -> *mut c_void {
     let ptr;
     unsafe {
         asm!("mrs {}, tpidr_el0", out(reg) ptr, options(nostack, preserves_flags, readonly));

--- a/src/arch/arm.rs
+++ b/src/arch/arm.rs
@@ -179,13 +179,13 @@ pub(super) unsafe fn clone(
 #[inline]
 pub(super) unsafe fn set_thread_pointer(ptr: *mut c_void) {
     rustix::runtime::arm_set_tls(ptr).expect("arm_set_tls");
-    debug_assert_eq!(get_thread_pointer(), ptr);
+    debug_assert_eq!(thread_pointer(), ptr);
 }
 
 /// Read the value of the platform thread-pointer register.
 #[cfg(feature = "origin-thread")]
 #[inline]
-pub(super) fn get_thread_pointer() -> *mut c_void {
+pub(super) fn thread_pointer() -> *mut c_void {
     let ptr;
     unsafe {
         asm!("mrc p15, 0, {}, c13, c0, 3", out(reg) ptr);

--- a/src/arch/riscv64.rs
+++ b/src/arch/riscv64.rs
@@ -178,13 +178,13 @@ pub(super) unsafe fn clone(
 #[inline]
 pub(super) unsafe fn set_thread_pointer(ptr: *mut c_void) {
     asm!("mv tp, {}", in(reg) ptr);
-    debug_assert_eq!(get_thread_pointer(), ptr);
+    debug_assert_eq!(thread_pointer(), ptr);
 }
 
 /// Read the value of the platform thread-pointer register.
 #[cfg(feature = "origin-thread")]
 #[inline]
-pub(super) fn get_thread_pointer() -> *mut c_void {
+pub(super) fn thread_pointer() -> *mut c_void {
     let ptr;
     unsafe {
         asm!("mv {}, tp", out(reg) ptr, options(nostack, preserves_flags, readonly));

--- a/src/arch/x86.rs
+++ b/src/arch/x86.rs
@@ -237,13 +237,13 @@ pub(super) unsafe fn set_thread_pointer(ptr: *mut c_void) {
     rustix::runtime::set_thread_area(&mut user_desc).expect("set_thread_area");
     asm!("mov gs, {0:x}", in(reg) ((user_desc.entry_number << 3) | 3) as u16);
     debug_assert_eq!(*ptr.cast::<*const c_void>(), ptr);
-    debug_assert_eq!(get_thread_pointer(), ptr);
+    debug_assert_eq!(thread_pointer(), ptr);
 }
 
 /// Read the value of the platform thread-pointer register.
 #[cfg(feature = "origin-thread")]
 #[inline]
-pub(super) fn get_thread_pointer() -> *mut c_void {
+pub(super) fn thread_pointer() -> *mut c_void {
     let ptr;
     unsafe {
         asm!("mov {}, DWORD PTR gs:0", out(reg) ptr, options(nostack, preserves_flags, readonly));

--- a/src/arch/x86_64.rs
+++ b/src/arch/x86_64.rs
@@ -183,13 +183,13 @@ pub(super) unsafe fn clone(
 pub(super) unsafe fn set_thread_pointer(ptr: *mut c_void) {
     rustix::runtime::set_fs(ptr);
     debug_assert_eq!(*ptr.cast::<*const c_void>(), ptr);
-    debug_assert_eq!(get_thread_pointer(), ptr);
+    debug_assert_eq!(thread_pointer(), ptr);
 }
 
 /// Read the value of the platform thread-pointer register.
 #[cfg(feature = "origin-thread")]
 #[inline]
-pub(super) fn get_thread_pointer() -> *mut c_void {
+pub(super) fn thread_pointer() -> *mut c_void {
     let ptr;
     unsafe {
         asm!("mov {}, QWORD PTR fs:0", out(reg) ptr, options(nostack, preserves_flags, readonly));

--- a/src/relocate.rs
+++ b/src/relocate.rs
@@ -24,6 +24,8 @@
 //! need to rely on testing the code to make sure it doesn't segfault in any
 //! case. And, `#![no_builtins]` interferes with LTO, so we don't use it.
 
+#![allow(clippy::cmp_null)]
+
 use crate::arch::{relocation_load, relocation_mprotect_readonly, relocation_store};
 use core::ffi::c_void;
 use core::ptr::{from_exposed_addr, null, null_mut};


### PR DESCRIPTION
This follows [Rust convention].

[Rust convention]: https://rust-lang.github.io/api-guidelines/naming.html#getter-names-follow-rust-convention-c-getter