### PR TITLE
Mark rcx and r11 as clobbered in the relro `mprotect`.

### DIFF
--- a/src/arch/x86_64.rs
+++ b/src/arch/x86_64.rs
@@ -126,6 +126,8 @@ pub(super) unsafe fn relocation_mprotect_readonly(ptr: usize, len: usize) {
         in("rdi") ptr,
         in("rsi") len,
         in("rdx") PROT_READ,
+        lateout("rcx") _,
+        lateout("r11") _,
         options(nostack, preserves_flags),
     );
 


### PR DESCRIPTION
On x86-64, rcx and r11 are clobbered by syscalls, so mark them as clobbered in the relro mprotect too.