### PR TITLE
Switch from log to tracing

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ linux-raw-sys = { version = "0.4.9", default-features = false, features = ["gene
 rustix = { version = "0.38.17", default-features = false }
 bitflags = { version = "2.4.0", default-features = false }
 memoffset = { version = "0.9.0", optional = true }
-log = { version = "0.4.14", default-features = false, optional = true }
+tracing = { version = "0.1.37", default-features = false, optional = true }
 rustix-futex-sync = "0.1.0"
 
 # Optional logging backends for use with "origin-program". You can use any
@@ -65,6 +65,8 @@ rustc-dep-of-std = [
     "dep:compiler_builtins",
 ]
 
+log = ["tracing/log"]
+
 # Use origin's implementation of program startup and shutdown.
 origin-program = []
 
@@ -89,7 +91,7 @@ atomic-dbg-logger = ["atomic-dbg/log"]
 env_logger = ["dep:env_logger", "init-fini-arrays"]
 
 # Disable logging.
-max_level_off = ["log/max_level_off"]
+# max_level_off = ["log/max_level_off"]
 
 # Enable features which depend on the Rust global allocator, such as functions
 # that return owned strings or `Vec`s.

--- a/src/log.rs
+++ b/src/log.rs
@@ -23,12 +23,12 @@ fn init() {
     // process. We started the program earlier than this, but we couldn't
     // initialize the logger until we initialized the main thread.
     #[cfg(feature = "origin-program")]
-    log::trace!(target: "origin::program", "Program started");
+    tracing::trace!(target: "origin::program", "Program started");
 
     // Log the main thread id. Similarly, we initialized the main thread
     // earlier than this, but we couldn't log until now.
     #[cfg(feature = "origin-thread")]
-    log::trace!(
+    tracing::trace!(
         target: "origin::thread",
         "Main Thread[{:?}] initialized",
         crate::thread::current_thread_id().as_raw_nonzero()

--- a/src/program.rs
+++ b/src/program.rs
@@ -120,7 +120,7 @@ pub(super) unsafe extern "C" fn entry(mem: *mut usize) -> ! {
 
         while init != init_end {
             #[cfg(feature = "log")]
-            log::trace!(
+            tracing::trace!(
                 "Calling `.init_array`-registered function `{:?}({:?}, {:?}, {:?})`",
                 *init,
                 argc,
@@ -141,13 +141,13 @@ pub(super) unsafe extern "C" fn entry(mem: *mut usize) -> ! {
         }
 
         #[cfg(feature = "log")]
-        log::trace!("Calling `origin_main({:?}, {:?}, {:?})`", argc, argv, envp);
+        tracing::trace!("Calling `origin_main({:?}, {:?}, {:?})`", argc, argv, envp);
 
         // Call `origin_main`.
         let status = origin_main(argc as usize, argv, envp);
 
         #[cfg(feature = "log")]
-        log::trace!("`origin_main` returned `{:?}`", status);
+        tracing::trace!("`origin_main` returned `{:?}`", status);
 
         // Run functions registered with `at_exit`, and exit with
         // `origin_main`'s return value.
@@ -276,7 +276,7 @@ pub fn exit(status: c_int) -> ! {
         let mut dtors = DTORS.lock();
         if let Some(dtor) = dtors.pop() {
             #[cfg(feature = "log")]
-            log::trace!("Calling `at_exit`-registered function");
+            tracing::trace!("Calling `at_exit`-registered function");
 
             dtor();
         } else {
@@ -311,7 +311,7 @@ pub fn exit(status: c_int) -> ! {
             fini = fini.sub(1);
 
             #[cfg(feature = "log")]
-            log::trace!("Calling `.fini_array`-registered function `{:?}()`", *fini);
+            tracing::trace!("Calling `.fini_array`-registered function `{:?}()`", *fini);
 
             (*fini)();
         }
@@ -337,7 +337,7 @@ pub fn exit_immediately(status: c_int) -> ! {
     #[cfg(feature = "origin-program")]
     {
         #[cfg(feature = "log")]
-        log::trace!("Program exiting with status `{:?}`", status);
+        tracing::trace!("Program exiting with status `{:?}`", status);
 
         // Call `rustix` to exit the program.
         rustix::runtime::exit_group(status)

--- a/src/thread/linux_raw.rs
+++ b/src/thread/linux_raw.rs
@@ -535,7 +535,7 @@ pub fn create_thread(
         );
         if clone_res >= 0 {
             #[cfg(feature = "log")]
-            log::trace!(
+            tracing::trace!(
                 "Thread[{:?}] launched thread Thread[{:?}] with stack_size={} and guard_size={}",
                 current_thread_id().as_raw_nonzero(),
                 clone_res,
@@ -563,7 +563,7 @@ pub(super) unsafe extern "C" fn entry(fn_: *mut Box<dyn FnOnce() -> Option<Box<d
     let fn_ = Box::from_raw(fn_);
 
     #[cfg(feature = "log")]
-    log::trace!(
+    tracing::trace!(
         "Thread[{:?}] launched",
         current_thread_id().as_raw_nonzero()
     );
@@ -636,7 +636,7 @@ unsafe fn exit_thread() -> ! {
         let current_guard_size = current.0.as_ref().guard_size;
 
         #[cfg(feature = "log")]
-        log::trace!("Thread[{:?}] exiting as detached", current_thread_id);
+        tracing::trace!("Thread[{:?}] exiting as detached", current_thread_id);
         debug_assert_eq!(e, DETACHED);
 
         // Deallocate the `ThreadData`.
@@ -658,8 +658,8 @@ unsafe fn exit_thread() -> ! {
         // The thread was not detached, so its memory will be freed when it's
         // joined.
         #[cfg(feature = "log")]
-        if log::log_enabled!(log::Level::Trace) {
-            log::trace!(
+        if tracing::log_enabled!(tracing::Level::Trace) {
+            tracing::trace!(
                 "Thread[{:?}] exiting as joinable",
                 current.0.as_ref().thread_id.load(SeqCst)
             );
@@ -681,8 +681,8 @@ pub(crate) fn call_thread_dtors(current: Thread) {
     // as the thread is alive.
     while let Some(func) = unsafe { current.0.as_mut().dtors.pop() } {
         #[cfg(feature = "log")]
-        if log::log_enabled!(log::Level::Trace) {
-            log::trace!(
+        if tracing::log_enabled!(tracing::Level::Trace) {
+            tracing::trace!(
                 "Thread[{:?}] calling `at_thread_exit`-registered function",
                 unsafe { current.0.as_ref().thread_id.load(SeqCst) },
             );
@@ -707,8 +707,8 @@ pub unsafe fn detach_thread(thread: Thread) {
     let thread_id = thread.0.as_ref().thread_id.load(SeqCst);
 
     #[cfg(feature = "log")]
-    if log::log_enabled!(log::Level::Trace) {
-        log::trace!(
+    if tracing::log_enabled!(tracing::Level::Trace) {
+        tracing::trace!(
             "Thread[{:?}] marked as detached by Thread[{:?}]",
             thread_id,
             current_thread_id().as_raw_nonzero()
@@ -736,8 +736,8 @@ pub unsafe fn join_thread(thread: Thread) {
     let thread_id = thread.0.as_ref().thread_id.load(SeqCst);
 
     #[cfg(feature = "log")]
-    if log::log_enabled!(log::Level::Trace) {
-        log::trace!(
+    if tracing::log_enabled!(tracing::Level::Trace) {
+        tracing::trace!(
             "Thread[{:?}] is being joined by Thread[{:?}]",
             thread_id,
             current_thread_id().as_raw_nonzero()
@@ -788,8 +788,8 @@ unsafe fn wait_for_thread_exit(thread: Thread) {
 
 #[cfg(feature = "log")]
 fn log_thread_to_be_freed(thread_id: i32) {
-    if log::log_enabled!(log::Level::Trace) {
-        log::trace!("Thread[{:?}] memory being freed", thread_id);
+    if tracing::log_enabled!(tracing::Level::Trace) {
+        tracing::trace!("Thread[{:?}] memory being freed", thread_id);
     }
 }
 


### PR DESCRIPTION
This pr attempts to replace log with tracing in a way that is backwards compatible. However after staring at the code for a while I do start wondering if it's the best approach. Unfortunately the current implementation is kinda broken since log is called in init without being properly feature gated. I feel like it would be cleaner to just implement it in a somewhat backward incompatible way by removing the usage in init including the env_logger implementation and just add a log feature for users of the log crate. I don't think it make sense to have a breaking release just for logging but at the same time it something that should be done eventually.