### PR TITLE
Use `.cast_mut` and `addr_of` to avoid `as` casting raw pointers.

### DIFF
--- a/src/arch/x86.rs
+++ b/src/arch/x86.rs
@@ -11,7 +11,7 @@ use {
     alloc::boxed::Box,
     core::any::Any,
     core::ffi::c_void,
-    core::ptr::invalid,
+    core::ptr::invalid_mut,
     linux_raw_sys::general::{__NR_clone, __NR_exit, __NR_munmap},
     rustix::thread::RawPid,
 };
@@ -207,7 +207,11 @@ pub(super) unsafe fn clone(
         "pop esi",            // Restore incoming register value.
 
         entry = sym super::thread::entry,
-        inout("eax") &[newtls as *mut c_void, invalid(__NR_clone as usize), fn_ as *mut c_void] => r0,
+        inout("eax") &[
+            newtls.cast::<c_void>().cast_mut(),
+            invalid_mut(__NR_clone as usize),
+            fn_.cast::<c_void>()
+        ] => r0,
         in("ebx") flags,
         in("ecx") child_stack,
         in("edx") parent_tid,

--- a/src/thread/libc.rs
+++ b/src/thread/libc.rs
@@ -266,5 +266,5 @@ pub fn yield_current_thread() {
 /// Return the address of `__dso_handle`, appropriately casted.
 unsafe fn dso_handle() -> *mut c_void {
     let dso_handle: *const *const c_void = &__dso_handle;
-    dso_handle as *mut c_void
+    dso_handle.cast::<c_void>().cast_mut()
 }

--- a/src/thread/linux_raw.rs
+++ b/src/thread/linux_raw.rs
@@ -259,7 +259,9 @@ pub(super) unsafe fn initialize_main_thread(mem: *mut c_void) {
     // See <https://lwn.net/Articles/631631/> for details.
     let execfn = linux_execfn().to_bytes_with_nul();
     let stack_base = execfn.as_ptr().add(execfn.len());
-    let stack_base = stack_base.map_addr(|ptr| round_up(ptr, page_size())) as *mut c_void;
+    let stack_base = stack_base
+        .map_addr(|ptr| round_up(ptr, page_size()))
+        .cast_mut();
 
     // We're running before any user code, so the startup soft stack limit is
     // the effective stack size. Linux sets up inaccessible memory at the end


### PR DESCRIPTION
`as` casts can do many different things; use the more specific `cast`, `cast_mut`, and `addr_of` to be more specific about the intention of pointer conversions.