### PR TITLE
Fix `atomic-dbg-logger` to depend on `init-fini-arrays`.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -85,7 +85,7 @@ external-start = ["rustix/use-explicitly-provided-auxv", "rustix/runtime", "orig
 # The loggers depend on a `.init_array` entry to initialize themselves, and
 # `env_logger` needs it so that `c-scape` can initialize environment variables
 # and make `RUST_LOG` available.
-atomic-dbg-logger = ["atomic-dbg/log"]
+atomic-dbg-logger = ["atomic-dbg/log", "init-fini-arrays"]
 env_logger = ["dep:env_logger", "init-fini-arrays"]
 
 # Disable logging.


### PR DESCRIPTION
`atomic-dbg-logger` needs to be initialized in a `.init_array` function too, so add a dependency on `init-fini-arrays`.