### PR TITLE
Split `init-fini-arrays` into separate features.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -108,7 +108,13 @@ signal = ["rustix/runtime"]
 param = ["rustix/param"]
 
 # Enable support for ELF `.init_array` and `.fini_array`.
-init-fini-arrays = []
+init-fini-arrays = ["init-array", "fini-array"]
+
+# Enable support for ELF `.init_array`.
+init-array = []
+
+# Enable support for ELF `.fini_array`.
+fini-array = []
 
 # Enable highly experimental support for performing startup-time relocations,
 # needed to support statically-linked PIE executables.

--- a/src/program.rs
+++ b/src/program.rs
@@ -96,7 +96,7 @@ pub(super) unsafe extern "C" fn entry(mem: *mut usize) -> ! {
     init_runtime(mem, envp);
 
     // Call the functions registered via `.init_array`.
-    #[cfg(feature = "init-fini-arrays")]
+    #[cfg(feature = "init-array")]
     {
         use core::arch::asm;
         use core::ffi::c_void;
@@ -287,7 +287,7 @@ pub fn exit(status: c_int) -> ! {
     // Call the `.fini_array` functions, in reverse order. We only do this
     // in "origin-program" mode because if we're using libc, libc does this
     // in `exit`.
-    #[cfg(all(feature = "init-fini-arrays", feature = "origin-program"))]
+    #[cfg(all(feature = "fini-array", feature = "origin-program"))]
     unsafe {
         use core::arch::asm;
         use core::ffi::c_void;


### PR DESCRIPTION
Define separate features for init and fini arrays. Some use cases need init arrays and don't need fini arrays due to using mechanisms like `__cxa_atexit` instead.