### PR TITLE
Minor code simplifications.

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ For fully static linking, there are two options:
 
  - Build with `RUSTFLAGS=-C target-feature=+crt-static` and enable Origin's
    `experimental-relocate` feature. This allows PIE mode to work, however it
-   does so by enabling some experimental code in origin for performing
+   does so by enabling some experimental code in Origin for performing
    relocations.
 
 [basic example]: https://github.com/sunfishcode/origin/blob/main/example-crates/basic/README.md

--- a/src/arch/aarch64.rs
+++ b/src/arch/aarch64.rs
@@ -142,8 +142,8 @@ pub(super) unsafe fn clone(
     flags: u32,
     child_stack: *mut c_void,
     parent_tid: *mut RawPid,
-    newtls: *mut c_void,
     child_tid: *mut RawPid,
+    newtls: *mut c_void,
     fn_: *mut Box<dyn FnOnce() -> Option<Box<dyn Any>> + Send>,
 ) -> isize {
     let r0;

--- a/src/arch/arm.rs
+++ b/src/arch/arm.rs
@@ -142,8 +142,8 @@ pub(super) unsafe fn clone(
     flags: u32,
     child_stack: *mut c_void,
     parent_tid: *mut RawPid,
-    newtls: *mut c_void,
     child_tid: *mut RawPid,
+    newtls: *mut c_void,
     fn_: *mut Box<dyn FnOnce() -> Option<Box<dyn Any>> + Send>,
 ) -> isize {
     let r0;

--- a/src/arch/riscv64.rs
+++ b/src/arch/riscv64.rs
@@ -142,8 +142,8 @@ pub(super) unsafe fn clone(
     flags: u32,
     child_stack: *mut c_void,
     parent_tid: *mut RawPid,
-    newtls: *mut c_void,
     child_tid: *mut RawPid,
+    newtls: *mut c_void,
     fn_: *mut Box<dyn FnOnce() -> Option<Box<dyn Any>> + Send>,
 ) -> isize {
     let r0;

--- a/src/arch/x86.rs
+++ b/src/arch/x86.rs
@@ -147,8 +147,8 @@ pub(super) unsafe fn clone(
     flags: u32,
     child_stack: *mut c_void,
     parent_tid: *mut RawPid,
-    newtls: *mut c_void,
     child_tid: *mut RawPid,
+    newtls: *mut c_void,
     fn_: *mut Box<dyn FnOnce() -> Option<Box<dyn Any>> + Send>,
 ) -> isize {
     let mut gs: u32 = 0;

--- a/src/thread/linux_raw.rs
+++ b/src/thread/linux_raw.rs
@@ -514,27 +514,12 @@ pub fn create_thread(
             | CloneFlags::CHILD_SETTID
             | CloneFlags::PARENT_SETTID;
         let thread_id_ptr = (*metadata).thread.thread_id.as_ptr();
-        #[cfg(target_arch = "x86_64")]
         let clone_res = clone(
             flags.bits(),
             stack.cast(),
             thread_id_ptr,
             thread_id_ptr,
             newtls.cast::<u8>().cast(),
-            Box::into_raw(Box::new(fn_)),
-        );
-        #[cfg(any(
-            target_arch = "x86",
-            target_arch = "aarch64",
-            target_arch = "arm",
-            target_arch = "riscv64"
-        ))]
-        let clone_res = clone(
-            flags.bits(),
-            stack.cast(),
-            thread_id_ptr,
-            newtls.cast::<u8>().cast(),
-            thread_id_ptr,
             Box::into_raw(Box::new(fn_)),
         );
         if clone_res >= 0 {


### PR DESCRIPTION
Reorder the arguments on the target-specific `clone` functions so they match each other. They aren't ABI-exposed, and making them all the same means the calling code doesn't need to be platform-specific.