### PR TITLE
Increase the default stack size.

### DIFF
--- a/example-crates/basic/src/main.rs
+++ b/example-crates/basic/src/main.rs
@@ -17,7 +17,7 @@ fn main() {
             }));
             None
         }),
-        2 * 1024 * 1024,
+        default_stack_size(),
         default_guard_size(),
     )
     .unwrap();

--- a/example-crates/external-start/src/main.rs
+++ b/example-crates/external-start/src/main.rs
@@ -72,7 +72,7 @@ unsafe fn origin_main(_argc: usize, _argv: *mut *mut u8, _envp: *mut *mut u8) ->
             }));
             None
         }),
-        2 * 1024 * 1024,
+        default_stack_size(),
         default_guard_size(),
     )
     .unwrap();

--- a/example-crates/no-std/src/main.rs
+++ b/example-crates/no-std/src/main.rs
@@ -42,7 +42,7 @@ fn start(_argc: isize, _argv: *const *const u8) -> isize {
             }));
             None
         }),
-        2 * 1024 * 1024,
+        default_stack_size(),
         default_guard_size(),
     )
     .unwrap();

--- a/example-crates/origin-start-lto/src/main.rs
+++ b/example-crates/origin-start-lto/src/main.rs
@@ -43,7 +43,7 @@ unsafe fn origin_main(_argc: usize, _argv: *mut *mut u8, _envp: *mut *mut u8) ->
             }));
             None
         }),
-        2 * 1024 * 1024,
+        default_stack_size(),
         default_guard_size(),
     )
     .unwrap();

--- a/example-crates/origin-start/src/main.rs
+++ b/example-crates/origin-start/src/main.rs
@@ -43,7 +43,7 @@ unsafe fn origin_main(_argc: usize, _argv: *mut *mut u8, _envp: *mut *mut u8) ->
             }));
             None
         }),
-        2 * 1024 * 1024,
+        default_stack_size(),
         default_guard_size(),
     )
     .unwrap();

--- a/src/thread/linux_raw.rs
+++ b/src/thread/linux_raw.rs
@@ -947,7 +947,7 @@ pub fn default_stack_size() -> usize {
     //
     // SAFETY: `STARTUP_STACK_SIZE` has already been initialized by
     // [`initialize_startup_thread_info`].
-    unsafe { max(page_size() * 2, STARTUP_STACK_SIZE) }
+    unsafe { max(0x20000, STARTUP_STACK_SIZE) }
 }
 
 /// Return the default guard size for new threads.


### PR DESCRIPTION
The previous very low size was seeing frequent stack overflows, so increase it.