### PR TITLE
Use `smallvec` for dtor lists.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,6 +40,7 @@ errno = { version = "0.3.3", default-features = false, optional = true }
 core = { version = "1.0.0", optional = true, package = "rustc-std-workspace-core" }
 alloc = { version = "1.0.0", optional = true, package = "rustc-std-workspace-alloc" }
 compiler_builtins = { version = "0.1.101", optional = true }
+smallvec = { version = "1.11.1", features = ["const_new"] }
 
 [target.'cfg(not(target_arch = "arm"))'.dependencies.unwinding]
 version = "0.2.0"

--- a/src/thread/linux_raw.rs
+++ b/src/thread/linux_raw.rs
@@ -2,7 +2,6 @@
 
 use crate::arch::{clone, munmap_and_exit_thread, set_thread_pointer, thread_pointer, TLS_OFFSET};
 use alloc::boxed::Box;
-use alloc::vec::Vec;
 use core::any::Any;
 use core::cmp::max;
 use core::ffi::c_void;
@@ -63,7 +62,9 @@ struct ThreadData {
     stack_size: usize,
     guard_size: usize,
     map_size: usize,
-    dtors: Vec<Box<dyn FnOnce()>>,
+
+    // Support a few dtors before using dynamic allocation.
+    dtors: smallvec::SmallVec<[Box<dyn FnOnce()>; 4]>,
 }
 
 // Values for `ThreadData::detached`.
@@ -87,7 +88,7 @@ impl ThreadData {
             stack_size,
             guard_size,
             map_size,
-            dtors: Vec::new(),
+            dtors: smallvec::SmallVec::new(),
         }
     }
 }


### PR DESCRIPTION
Use `smallvec` for `at_exit` and `at_thread_exit` dtor lists. This helps us follow the POSIX rule that at least 32 functions be registerable, and helps origin run in settings where thread destructors are registered from within a malloc implementation.