### PR TITLE
Redesign `create_thread` to avoid dynamic allocation.

### DIFF
--- a/example-crates/basic/src/main.rs
+++ b/example-crates/basic/src/main.rs
@@ -9,18 +9,21 @@ fn main() {
         eprintln!("Hello from a main-thread at_thread_exit handler")
     }));
 
-    let thread = create_thread(
-        Box::new(|| {
-            eprintln!("Hello from child thread");
-            at_thread_exit(Box::new(|| {
-                eprintln!("Hello from child thread's at_thread_exit handler")
-            }));
-            None
-        }),
-        default_stack_size(),
-        default_guard_size(),
-    )
-    .unwrap();
+    let thread = unsafe {
+        create_thread(
+            |_args| {
+                eprintln!("Hello from child thread");
+                at_thread_exit(Box::new(|| {
+                    eprintln!("Hello from child thread's at_thread_exit handler")
+                }));
+                None
+            },
+            &[],
+            default_stack_size(),
+            default_guard_size(),
+        )
+        .unwrap()
+    };
 
     unsafe {
         join_thread(thread);

--- a/example-crates/external-start/src/main.rs
+++ b/example-crates/external-start/src/main.rs
@@ -65,13 +65,14 @@ unsafe fn origin_main(_argc: usize, _argv: *mut *mut u8, _envp: *mut *mut u8) ->
     }));
 
     let thread = create_thread(
-        Box::new(|| {
+        |_args| {
             eprintln!("Hello from child thread");
             at_thread_exit(Box::new(|| {
                 eprintln!("Hello from child thread's at_thread_exit handler")
             }));
             None
-        }),
+        },
+        &[],
         default_stack_size(),
         default_guard_size(),
     )

--- a/example-crates/no-std/src/main.rs
+++ b/example-crates/no-std/src/main.rs
@@ -34,18 +34,21 @@ fn start(_argc: isize, _argv: *const *const u8) -> isize {
         eprintln!("Hello from a main-thread at_thread_exit handler")
     }));
 
-    let thread = create_thread(
-        Box::new(|| {
-            eprintln!("Hello from child thread");
-            at_thread_exit(Box::new(|| {
-                eprintln!("Hello from child thread's at_thread_exit handler")
-            }));
-            None
-        }),
-        default_stack_size(),
-        default_guard_size(),
-    )
-    .unwrap();
+    let thread = unsafe {
+        create_thread(
+            |_args| {
+                eprintln!("Hello from child thread");
+                at_thread_exit(Box::new(|| {
+                    eprintln!("Hello from child thread's at_thread_exit handler")
+                }));
+                None
+            },
+            &[],
+            default_stack_size(),
+            default_guard_size(),
+        )
+        .unwrap()
+    };
 
     unsafe {
         join_thread(thread);

--- a/example-crates/origin-start-lto/src/main.rs
+++ b/example-crates/origin-start-lto/src/main.rs
@@ -36,13 +36,14 @@ unsafe fn origin_main(_argc: usize, _argv: *mut *mut u8, _envp: *mut *mut u8) ->
     }));
 
     let thread = create_thread(
-        Box::new(|| {
+        |_args| {
             eprintln!("Hello from child thread");
             at_thread_exit(Box::new(|| {
                 eprintln!("Hello from child thread's at_thread_exit handler")
             }));
             None
-        }),
+        },
+        &[],
         default_stack_size(),
         default_guard_size(),
     )

--- a/example-crates/origin-start/src/main.rs
+++ b/example-crates/origin-start/src/main.rs
@@ -36,13 +36,14 @@ unsafe fn origin_main(_argc: usize, _argv: *mut *mut u8, _envp: *mut *mut u8) ->
     }));
 
     let thread = create_thread(
-        Box::new(|| {
+        |_args| {
             eprintln!("Hello from child thread");
             at_thread_exit(Box::new(|| {
                 eprintln!("Hello from child thread's at_thread_exit handler")
             }));
             None
-        }),
+        },
+        &[],
         default_stack_size(),
         default_guard_size(),
     )

--- a/src/arch/aarch64.rs
+++ b/src/arch/aarch64.rs
@@ -8,8 +8,6 @@ use linux_raw_sys::general::__NR_rt_sigreturn;
 use linux_raw_sys::general::{__NR_mprotect, PROT_READ};
 #[cfg(feature = "origin-thread")]
 use {
-    alloc::boxed::Box,
-    core::any::Any,
     core::ffi::c_void,
     linux_raw_sys::general::{__NR_clone, __NR_exit, __NR_munmap},
     rustix::thread::RawPid,
@@ -131,6 +129,10 @@ pub(super) unsafe fn relocation_mprotect_readonly(ptr: usize, len: usize) {
     assert_eq!(r0, 0);
 }
 
+/// The required alignment for the stack pointer.
+#[cfg(feature = "origin-thread")]
+pub(super) const STACK_ALIGNMENT: usize = 16;
+
 /// A wrapper around the Linux `clone` system call.
 ///
 /// This can't be implemented in `rustix` because the child starts executing at
@@ -144,7 +146,8 @@ pub(super) unsafe fn clone(
     parent_tid: *mut RawPid,
     child_tid: *mut RawPid,
     newtls: *mut c_void,
-    fn_: *mut Box<dyn FnOnce() -> Option<Box<dyn Any>> + Send>,
+    fn_: extern "C" fn(),
+    num_args: usize,
 ) -> isize {
     let r0;
     asm!(
@@ -153,6 +156,8 @@ pub(super) unsafe fn clone(
 
         // Child thread.
         "mov x0, {fn_}",      // Pass `fn_` as the first argument.
+        "mov x1, sp",         // Pass the args pointer as the second argument.
+        "mov x2, {num_args}", // Pass `num_args` as the third argument.
         "mov x29, xzr",       // Zero the frame address.
         "mov x30, xzr",       // Zero the return address.
         "b {entry}",          // Call `entry`.
@@ -162,6 +167,7 @@ pub(super) unsafe fn clone(
 
         entry = sym super::thread::entry,
         fn_ = in(reg) fn_,
+        num_args = in(reg) num_args,
         in("x8") __NR_clone,
         inlateout("x0") flags as usize => r0,
         in("x1") child_stack,

--- a/src/arch/riscv64.rs
+++ b/src/arch/riscv64.rs
@@ -7,8 +7,6 @@ use core::arch::asm;
 use linux_raw_sys::general::{__NR_mprotect, PROT_READ};
 #[cfg(feature = "origin-thread")]
 use {
-    alloc::boxed::Box,
-    core::any::Any,
     core::ffi::c_void,
     linux_raw_sys::general::{__NR_clone, __NR_exit, __NR_munmap},
     rustix::thread::RawPid,
@@ -131,6 +129,10 @@ pub(super) unsafe fn relocation_mprotect_readonly(ptr: usize, len: usize) {
     assert_eq!(r0, 0);
 }
 
+/// The required alignment for the stack pointer.
+#[cfg(feature = "origin-thread")]
+pub(super) const STACK_ALIGNMENT: usize = 16;
+
 /// A wrapper around the Linux `clone` system call.
 ///
 /// This can't be implemented in `rustix` because the child starts executing at
@@ -144,7 +146,8 @@ pub(super) unsafe fn clone(
     parent_tid: *mut RawPid,
     child_tid: *mut RawPid,
     newtls: *mut c_void,
-    fn_: *mut Box<dyn FnOnce() -> Option<Box<dyn Any>> + Send>,
+    fn_: extern "C" fn(),
+    num_args: usize,
 ) -> isize {
     let r0;
     asm!(
@@ -153,6 +156,8 @@ pub(super) unsafe fn clone(
 
         // Child thread.
         "mv a0, {fn_}",       // Pass `fn_` as the first argument.
+        "mv a1, sp",          // Pass the args pointer as the second argument.
+        "mv a2, {num_args}",  // Pass `num_args` as the third argument.
         "mv fp, zero",        // Zero the frame address.
         "mv ra, zero",        // Zero the return address.
         "tail {entry}",       // Call `entry`.
@@ -162,6 +167,7 @@ pub(super) unsafe fn clone(
 
         entry = sym super::thread::entry,
         fn_ = in(reg) fn_,
+        num_args = in(reg) num_args,
         in("a7") __NR_clone,
         inlateout("a0") flags as usize => r0,
         in("a1") child_stack,


### PR DESCRIPTION
Change `create_thread` from taking a boxed closure to taking a function pointer, as well as an array of pointers to be copied into the new thread to pass to the function. This avoids the need to dynamically allocate for a `Box`, and in particular it allows c-ward's `pthread_create` to be used from within `malloc` implementations.

And, implement thread return values, which is simpler with the removal of `Option<Box<dyn Any>>`.

These changes do create more work for users of the API, however it also gives them more control.

Fixes #85.