### PR TITLE
Add stack-smashing protector support.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ include = ["src", "Cargo.toml", "COPYRIGHT", "LICENSE*", "/*.md"]
 
 [dependencies]
 linux-raw-sys = { version = "0.4.9", default-features = false, features = ["general", "no_std", "elf"] }
-rustix = { version = "0.38.17", default-features = false }
+rustix = { version = "0.38.26", default-features = false }
 bitflags = { version = "2.4.0", default-features = false }
 memoffset = { version = "0.9.0", optional = true }
 log = { version = "0.4.14", default-features = false, optional = true }


### PR DESCRIPTION
Add a canary field to the thread metadata, and add a `__stack_chk_guard` global variable.