### PR TITLE
Fix the location of the thread metadata on riscv64

### DIFF
--- a/test-crates/tls/Cargo.toml
+++ b/test-crates/tls/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "tls"
+version = "0.0.0"
+edition = "2021"
+publish = false
+
+[dependencies]
+origin = { path = "../..", default-features = false, features = ["origin-thread", "origin-start"] }
+atomic-dbg = { version = "0.1.8", default-features = false }
+rustix-dlmalloc = { version = "0.1.0", features = ["global"] }
+compiler_builtins = { version = "0.1.101", features = ["mem"] }
+
+# This is just a test crate, and not part of the origin workspace.
+[workspace]

--- a/test-crates/tls/README.md
+++ b/test-crates/tls/README.md
@@ -1,0 +1,3 @@
+This is similar to the `origin-start` example, but adds `#[thread_local]`
+variables and a bunch of asserts to ensure that they're initialized and
+mutated properly.

--- a/test-crates/tls/build.rs
+++ b/test-crates/tls/build.rs
@@ -1,0 +1,3 @@
+fn main() {
+    println!("cargo:rustc-link-arg=-nostartfiles");
+}

--- a/test-crates/tls/src/main.rs
+++ b/test-crates/tls/src/main.rs
@@ -1,0 +1,128 @@
+//! Like `origin-start`, but add a `#[thread_local]` variable and asserts
+//! to ensure that it works.
+
+#![no_std]
+#![no_main]
+#![allow(internal_features)]
+#![feature(lang_items)]
+#![feature(core_intrinsics)]
+#![feature(thread_local)]
+#![feature(strict_provenance)]
+#![feature(const_mut_refs)]
+
+extern crate alloc;
+extern crate compiler_builtins;
+
+use alloc::boxed::Box;
+use atomic_dbg::dbg;
+use core::arch::asm;
+use core::ptr::{addr_of_mut, invalid_mut};
+use origin::program::*;
+use origin::thread::*;
+
+#[panic_handler]
+fn panic(panic: &core::panic::PanicInfo<'_>) -> ! {
+    dbg!(panic);
+    core::intrinsics::abort();
+}
+
+#[lang = "eh_personality"]
+extern "C" fn eh_personality() {}
+
+#[global_allocator]
+static GLOBAL_ALLOCATOR: rustix_dlmalloc::GlobalDlmalloc = rustix_dlmalloc::GlobalDlmalloc;
+
+#[no_mangle]
+unsafe fn origin_main(_argc: usize, _argv: *mut *mut u8, _envp: *mut *mut u8) -> i32 {
+    // Assert that the main thread initialized its TLS properly.
+    check_eq(TEST_DATA.0);
+
+    // Mutate one of the TLS fields.
+    THREAD_LOCAL[1] = invalid_mut(77);
+
+    // Assert that the mutation happened properly.
+    check_eq([TEST_DATA.0[0], invalid_mut(77), TEST_DATA.0[2]]);
+
+    at_exit(Box::new(|| {
+        // This is the last thing to run. Assert that we see the value stored
+        // by the `at_thread_exit` callback.
+        check_eq([TEST_DATA.0[0], invalid_mut(79), TEST_DATA.0[2]]);
+
+        // Mutate one of the TLS fields.
+        THREAD_LOCAL[1] = invalid_mut(80);
+    }));
+    at_thread_exit(Box::new(|| {
+        // Assert that we see the value stored at the end of `main`.
+        check_eq([TEST_DATA.0[0], invalid_mut(78), TEST_DATA.0[2]]);
+
+        // Mutate one of the TLS fields.
+        THREAD_LOCAL[1] = invalid_mut(79);
+    }));
+
+    let thread = create_thread(
+        |_args| {
+            // Assert that the new thread initialized its TLS properly.
+            check_eq(TEST_DATA.0);
+
+            // Mutate one of the TLS fields.
+            THREAD_LOCAL[1] = invalid_mut(175);
+
+            // Assert that the mutation happened properly.
+            check_eq([TEST_DATA.0[0], invalid_mut(175), TEST_DATA.0[2]]);
+
+            at_thread_exit(Box::new(|| {
+                // Assert that we still see the value stored in the thread.
+                check_eq([TEST_DATA.0[0], invalid_mut(175), TEST_DATA.0[2]]);
+            }));
+
+            None
+        },
+        &[],
+        default_stack_size(),
+        default_guard_size(),
+    )
+    .unwrap();
+
+    join_thread(thread);
+
+    // Assert that the main thread's TLS is still in place.
+    check_eq([TEST_DATA.0[0], invalid_mut(77), TEST_DATA.0[2]]);
+
+    // Mutate one of the TLS fields.
+    THREAD_LOCAL[1] = invalid_mut(78);
+
+    // Assert that the mutation happened properly.
+    check_eq([TEST_DATA.0[0], invalid_mut(78), TEST_DATA.0[2]]);
+
+    exit(200);
+}
+
+struct SyncTestData([*const u32; 3]);
+unsafe impl Sync for SyncTestData {}
+static TEST_DATA: SyncTestData = unsafe {
+    SyncTestData([
+        invalid_mut(0xa0b1a2b3a4b5a6b7),
+        addr_of_mut!(SOME_REGULAR_DATA),
+        addr_of_mut!(SOME_ZERO_DATA),
+    ])
+};
+
+#[thread_local]
+static mut THREAD_LOCAL: [*const u32; 3] = TEST_DATA.0;
+
+// Some variables to point to.
+static mut SOME_REGULAR_DATA: u32 = 909;
+static mut SOME_ZERO_DATA: u32 = 0;
+
+fn check_eq(data: [*const u32; 3]) {
+    unsafe {
+        // Check `THREAD_LOCAL` using a static address.
+        asm!("# {}", in(reg) THREAD_LOCAL.as_mut_ptr(), options(nostack, preserves_flags));
+        assert_eq!(THREAD_LOCAL, data);
+
+        // Check `THREAD_LOCAL` using a dynamic address.
+        let mut thread_local_addr: *mut [*const u32; 3] = &mut THREAD_LOCAL;
+        asm!("# {}", inout(reg) thread_local_addr, options(pure, nomem, nostack, preserves_flags));
+        assert_eq!(*thread_local_addr, data);
+    }
+}

--- a/tests/example_crates.rs
+++ b/tests/example_crates.rs
@@ -3,6 +3,10 @@
 
 #![feature(cfg_target_abi)]
 
+mod utils;
+
+use utils::{COMMON_STDERR, NO_ALLOC_STDERR};
+
 fn test_crate(
     name: &str,
     args: &[&str],
@@ -11,50 +15,8 @@ fn test_crate(
     stderr: &'static str,
     code: Option<i32>,
 ) {
-    use assert_cmd::Command;
-
-    #[cfg(target_arch = "x86_64")]
-    let arch = "x86_64";
-    #[cfg(target_arch = "aarch64")]
-    let arch = "aarch64";
-    #[cfg(target_arch = "riscv64")]
-    let arch = "riscv64gc";
-    #[cfg(target_arch = "x86")]
-    let arch = "i686";
-    #[cfg(target_arch = "arm")]
-    let arch = "armv5te";
-    #[cfg(target_env = "gnueabi")]
-    let env = "gnueabi";
-    #[cfg(all(target_env = "gnu", target_abi = "eabi"))]
-    let env = "gnueabi";
-    #[cfg(all(target_env = "gnu", not(target_abi = "eabi")))]
-    let env = "gnu";
-
-    let mut command = Command::new("cargo");
-    command.arg("run").arg("--quiet");
-    command.arg(&format!("--target={arch}-unknown-linux-{env}"));
-    command.args(args);
-    command.envs(envs.iter().copied());
-    command.current_dir(format!("example-crates/{name}"));
-    let assert = command.assert();
-    let assert = assert.stdout(stdout).stderr(stderr);
-    if let Some(code) = code {
-        assert.code(code);
-    } else {
-        assert.success();
-    }
+    utils::test_crate("example", name, args, envs, stdout, stderr, code);
 }
-
-/// Stderr output for most of the example crates.
-const COMMON_STDERR: &str = "Hello from main thread\n\
-    Hello from child thread\n\
-    Hello from child thread's at_thread_exit handler\n\
-    Goodbye from main\n\
-    Hello from a main-thread at_thread_exit handler\n\
-    Hello from an at_exit handler\n";
-
-/// Stderr output for the origin-start-no-alloc crate.
-const NO_ALLOC_STDERR: &str = "Hello!\n";
 
 #[test]
 fn example_crate_basic() {

--- a/tests/test_crates.rs
+++ b/tests/test_crates.rs
@@ -1,0 +1,49 @@
+//! Run the programs in the `test-crates` directory and compare their
+//! outputs with expected outputs.
+
+#![feature(cfg_target_abi)]
+
+mod utils;
+
+fn test_crate(
+    name: &str,
+    args: &[&str],
+    envs: &[(&str, &str)],
+    stdout: &'static str,
+    stderr: &'static str,
+    code: Option<i32>,
+) {
+    utils::test_crate("test", name, args, envs, stdout, stderr, code);
+}
+
+#[test]
+fn test_crate_tls() {
+    test_crate("tls", &["--release"], &[], "", "", Some(200));
+}
+
+#[test]
+fn test_crate_tls_crt_static() {
+    test_crate(
+        "tls",
+        &["--features=origin/experimental-relocate"],
+        &[("RUSTFLAGS", "-C target-feature=+crt-static")],
+        "",
+        "",
+        Some(200),
+    );
+}
+
+#[test]
+fn test_crate_tls_crt_static_relocation_static() {
+    test_crate(
+        "tls",
+        &[],
+        &[(
+            "RUSTFLAGS",
+            "-C target-feature=+crt-static -C relocation-model=static",
+        )],
+        "",
+        "",
+        Some(200),
+    );
+}

--- a/tests/utils/mod.rs
+++ b/tests/utils/mod.rs
@@ -1,0 +1,55 @@
+#![allow(dead_code)]
+
+pub fn test_crate(
+    dir: &str,
+    name: &str,
+    args: &[&str],
+    envs: &[(&str, &str)],
+    stdout: &'static str,
+    stderr: &'static str,
+    code: Option<i32>,
+) {
+    use assert_cmd::Command;
+
+    #[cfg(target_arch = "x86_64")]
+    let arch = "x86_64";
+    #[cfg(target_arch = "aarch64")]
+    let arch = "aarch64";
+    #[cfg(target_arch = "riscv64")]
+    let arch = "riscv64gc";
+    #[cfg(target_arch = "x86")]
+    let arch = "i686";
+    #[cfg(target_arch = "arm")]
+    let arch = "armv5te";
+    #[cfg(target_env = "gnueabi")]
+    let env = "gnueabi";
+    #[cfg(all(target_env = "gnu", target_abi = "eabi"))]
+    let env = "gnueabi";
+    #[cfg(all(target_env = "gnu", not(target_abi = "eabi")))]
+    let env = "gnu";
+
+    let mut command = Command::new("cargo");
+    command.arg("run").arg("--quiet");
+    command.arg(&format!("--target={arch}-unknown-linux-{env}"));
+    command.args(args);
+    command.envs(envs.iter().copied());
+    command.current_dir(format!("{dir}-crates/{name}"));
+    let assert = command.assert();
+    let assert = assert.stdout(stdout).stderr(stderr);
+    if let Some(code) = code {
+        assert.code(code);
+    } else {
+        assert.success();
+    }
+}
+
+/// Stderr output for most of the example crates.
+pub const COMMON_STDERR: &str = "Hello from main thread\n\
+    Hello from child thread\n\
+    Hello from child thread's at_thread_exit handler\n\
+    Goodbye from main\n\
+    Hello from a main-thread at_thread_exit handler\n\
+    Hello from an at_exit handler\n";
+
+/// Stderr output for the origin-start-no-alloc crate.
+pub const NO_ALLOC_STDERR: &str = "Hello!\n";


### PR DESCRIPTION
On riscv64, the thread pointer doesn't point to the first ABI-exposed field in the thread-local storage. Add an empty `thread_pointee` field to represent the place the thread pointer points to, and fix the address calculation code to point there.

And add a tls testcase that creates a `#[thread_local]` variable and checks that it's initialized and can be accessed properly.