### PR TITLE
Change the naming convention for the `thread` API.

### DIFF
--- a/example-crates/basic/src/main.rs
+++ b/example-crates/basic/src/main.rs
@@ -1,34 +1,35 @@
-use origin::program::*;
-use origin::thread::*;
+use origin::{program, thread};
 
 fn main() {
     eprintln!("Hello from main thread");
 
-    at_exit(Box::new(|| eprintln!("Hello from an at_exit handler")));
-    at_thread_exit(Box::new(|| {
-        eprintln!("Hello from a main-thread at_thread_exit handler")
+    program::at_exit(Box::new(|| {
+        eprintln!("Hello from an `program::at_exit` handler")
+    }));
+    thread::at_exit(Box::new(|| {
+        eprintln!("Hello from a main-thread `thread::at_exit` handler")
     }));
 
     let thread = unsafe {
-        create_thread(
+        thread::create(
             |_args| {
                 eprintln!("Hello from child thread");
-                at_thread_exit(Box::new(|| {
-                    eprintln!("Hello from child thread's at_thread_exit handler")
+                thread::at_exit(Box::new(|| {
+                    eprintln!("Hello from child thread's `thread::at_exit` handler")
                 }));
                 None
             },
             &[],
-            default_stack_size(),
-            default_guard_size(),
+            thread::default_stack_size(),
+            thread::default_guard_size(),
         )
         .unwrap()
     };
 
     unsafe {
-        join_thread(thread);
+        thread::join(thread);
     }
 
     eprintln!("Goodbye from main");
-    exit(0);
+    program::exit(0);
 }

--- a/example-crates/origin-start-no-alloc/src/main.rs
+++ b/example-crates/origin-start-no-alloc/src/main.rs
@@ -9,7 +9,7 @@
 extern crate compiler_builtins;
 
 use atomic_dbg::{dbg, eprintln};
-use origin::program::*;
+use origin::program;
 
 #[panic_handler]
 fn panic(panic: &core::panic::PanicInfo<'_>) -> ! {
@@ -27,5 +27,5 @@ unsafe fn origin_main(_argc: usize, _argv: *mut *mut u8, _envp: *mut *mut u8) ->
     // Unlike origin-start, this example can't create threads because origin's
     // thread support requires an allocator.
 
-    exit(0);
+    program::exit(0);
 }

--- a/tests/test_crates.rs
+++ b/tests/test_crates.rs
@@ -17,7 +17,7 @@ fn test_crate(
 }
 
 #[test]
-fn test_crate_tls() {
+fn test_tls() {
     test_crate(
         "origin-start",
         &["--bin=tls", "--release"],
@@ -29,7 +29,7 @@ fn test_crate_tls() {
 }
 
 #[test]
-fn test_crate_tls_crt_static() {
+fn test_tls_crt_static() {
     test_crate(
         "origin-start",
         &["--bin=tls", "--features=origin/experimental-relocate"],
@@ -41,7 +41,7 @@ fn test_crate_tls_crt_static() {
 }
 
 #[test]
-fn test_crate_tls_crt_static_relocation_static() {
+fn test_tls_crt_static_relocation_static() {
     test_crate(
         "origin-start",
         &["--bin=tls"],
@@ -56,6 +56,6 @@ fn test_crate_tls_crt_static_relocation_static() {
 }
 
 #[test]
-fn test_crate_thread_id() {
+fn test_thread_id() {
     test_crate("origin-start", &["--bin=thread-id"], &[], "", "", Some(201));
 }

--- a/tests/utils/mod.rs
+++ b/tests/utils/mod.rs
@@ -46,10 +46,10 @@ pub fn test_crate(
 /// Stderr output for most of the example crates.
 pub const COMMON_STDERR: &str = "Hello from main thread\n\
     Hello from child thread\n\
-    Hello from child thread's at_thread_exit handler\n\
+    Hello from child thread's `thread::at_exit` handler\n\
     Goodbye from main\n\
-    Hello from a main-thread at_thread_exit handler\n\
-    Hello from an at_exit handler\n";
+    Hello from a main-thread `thread::at_exit` handler\n\
+    Hello from an `program::at_exit` handler\n";
 
 /// Stderr output for the origin-start-no-alloc crate.
 pub const NO_ALLOC_STDERR: &str = "Hello!\n";


### PR DESCRIPTION
Change from functions like `create_thread` to `thread::create`, so that users can just import the public `thread` module instead of `thread::*`.

I considered also changing things like `thread::join(t)` to `t.join()`, but decided against it for now, and added comments to the thread module discussing this.