### PR TITLE
Fix the name of `set_current_id_after_a_fork` in the libc backend.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,7 +53,6 @@ assert_cmd = "2.0.12"
 [features]
 default = ["std", "log", "libc", "errno", "thread", "init-fini-arrays"]
 std = ["rustix/std", "bitflags/std"]
-set_thread_id = []
 rustc-dep-of-std = [
     "dep:core",
     "dep:alloc",
@@ -65,6 +64,9 @@ rustc-dep-of-std = [
     "rustix-futex-sync/rustc-dep-of-std",
     "dep:compiler_builtins",
 ]
+
+# Enable the `set_current_id_after_a_fork` function.
+set_thread_id = []
 
 # Use origin's implementation of program startup and shutdown.
 origin-program = []

--- a/src/thread/libc.rs
+++ b/src/thread/libc.rs
@@ -184,7 +184,7 @@ pub fn current_id() -> ThreadId {
 #[cfg(feature = "set_thread_id")]
 #[doc(hidden)]
 #[inline]
-pub unsafe fn set_current_thread_id_after_a_fork(tid: ThreadId) {
+pub unsafe fn set_current_id_after_a_fork(tid: ThreadId) {
     // Nothing to do here; libc does the update automatically.
     let _ = tid;
 }


### PR DESCRIPTION
This makes it match the linux_raw backend.