### PR TITLE
Fix `log::init` when feature `origin-thread` is enabled.

### DIFF
--- a/src/log.rs
+++ b/src/log.rs
@@ -31,6 +31,6 @@ fn init() {
     log::trace!(
         target: "origin::thread",
         "Main Thread[{:?}] initialized",
-        crate::thread::current_thread_id().as_raw_nonzero()
+        crate::thread::current_id().as_raw_nonzero()
     );
 }


### PR DESCRIPTION
`current_thread_id()` in `log::init` should be `current_id()` after commit 0d4b978. And `current_id` is simplified to avoid redundant checking `raw > 0`.