### PR TITLE
Add safety comments to the `thread_pointer` implementations.

### DIFF
--- a/src/arch/aarch64.rs
+++ b/src/arch/aarch64.rs
@@ -192,6 +192,7 @@ pub(super) unsafe fn set_thread_pointer(ptr: *mut c_void) {
 #[inline]
 pub(super) fn thread_pointer() -> *mut c_void {
     let ptr;
+    // SAFETY: This reads the thread register.
     unsafe {
         asm!("mrs {}, tpidr_el0", out(reg) ptr, options(nostack, preserves_flags, readonly));
     }

--- a/src/arch/arm.rs
+++ b/src/arch/arm.rs
@@ -193,6 +193,7 @@ pub(super) unsafe fn set_thread_pointer(ptr: *mut c_void) {
 #[inline]
 pub(super) fn thread_pointer() -> *mut c_void {
     let ptr;
+    // SAFETY: This reads the thread register.
     unsafe {
         asm!("mrc p15, 0, {}, c13, c0, 3", out(reg) ptr);
     }

--- a/src/arch/riscv64.rs
+++ b/src/arch/riscv64.rs
@@ -192,6 +192,7 @@ pub(super) unsafe fn set_thread_pointer(ptr: *mut c_void) {
 #[inline]
 pub(super) fn thread_pointer() -> *mut c_void {
     let ptr;
+    // SAFETY: This reads the thread register.
     unsafe {
         asm!("mv {}, tp", out(reg) ptr, options(nostack, preserves_flags, readonly));
     }

--- a/src/arch/x86.rs
+++ b/src/arch/x86.rs
@@ -259,6 +259,10 @@ pub(super) unsafe fn set_thread_pointer(ptr: *mut c_void) {
 #[inline]
 pub(super) fn thread_pointer() -> *mut c_void {
     let ptr;
+    // SAFETY: On x86, reading the thread register itself is expensive, so the
+    // ABI specifies that the thread pointer value is also stored in memory at
+    // offset 0 from the thread pointer value, where it can be read with just a
+    // load.
     unsafe {
         asm!("mov {}, gs:0", out(reg) ptr, options(nostack, preserves_flags, readonly));
     }

--- a/src/arch/x86_64.rs
+++ b/src/arch/x86_64.rs
@@ -199,6 +199,10 @@ pub(super) unsafe fn set_thread_pointer(ptr: *mut c_void) {
 #[inline]
 pub(super) fn thread_pointer() -> *mut c_void {
     let ptr;
+    // SAFETY: On x86_64, reading the thread register itself is expensive, so
+    // the ABI specifies that the thread pointer value is also stored in memory
+    // at offset 0 from the thread pointer value, where it can be read with
+    // just a load.
     unsafe {
         asm!("mov {}, fs:0", out(reg) ptr, options(nostack, preserves_flags, readonly));
     }

--- a/src/thread/linux_raw.rs
+++ b/src/thread/linux_raw.rs
@@ -953,6 +953,7 @@ pub fn current_id() -> ThreadId {
     // Don't use the `id` function here because it returns an `Option` to
     // handle the case where the thread has exited. We're querying the current
     // thread which we know is still running because we're on it.
+    //
     // SAFETY: All threads have been initialized, including the main thread
     // with `initialize_main`, so `current()` returns a valid pointer.
     let tid = unsafe { ThreadId::from_raw_unchecked(current().0.as_ref().thread_id.load(SeqCst)) };


### PR DESCRIPTION
Add `SAFETY:` comments to the unsafe blocks in the `thread_pointer` implementations.