### PR TITLE
Update CI to the latest Rust nightly.

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "nightly-2023-11-19"
+channel = "nightly-2023-12-09"
 components = ["rustc", "cargo", "rust-std", "rust-src", "rustfmt"]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,6 +7,7 @@
 #![cfg_attr(debug_assertions, feature(link_llvm_intrinsics))]
 #![cfg_attr(feature = "experimental-relocate", feature(cfg_relocation_model))]
 #![feature(strict_provenance)]
+#![feature(exposed_provenance)]
 #![deny(fuzzy_provenance_casts, lossy_provenance_casts)]
 #![no_std]
 


### PR DESCRIPTION
This requires adding `#![feature(exposed_provenance)]`.