### PR TITLE
Make the `rustix-futex-sync` dependency optional.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,19 +40,19 @@ errno = { version = "0.3.3", default-features = false, optional = true }
 core = { version = "1.0.0", optional = true, package = "rustc-std-workspace-core" }
 alloc = { version = "1.0.0", optional = true, package = "rustc-std-workspace-alloc" }
 compiler_builtins = { version = "0.1.101", optional = true }
-smallvec = { version = "1.11.1", features = ["const_new"] }
+smallvec = { version = "1.11.1", optional = true, features = ["const_new"] }
 
 [target.'cfg(not(target_arch = "arm"))'.dependencies.unwinding]
 version = "0.2.0"
 default-features = false
-features = [ "unwinder" ]
+features = ["unwinder"]
 
 [dev-dependencies]
 assert_cmd = "2.0.12"
 
 [features]
 default = ["std", "log", "libc", "errno", "thread", "init-fini-arrays"]
-std = ["rustix/std", "bitflags/std"]
+std = ["rustix/std", "bitflags/std", "alloc"]
 rustc-dep-of-std = [
     "dep:core",
     "dep:alloc",
@@ -72,10 +72,14 @@ set_thread_id = []
 origin-program = []
 
 # Use origin's implementation of thread startup and shutdown.
-origin-thread = ["memoffset", "rustix/runtime", "origin-program", "thread"]
+#
+# To use threads, it's also necessary to enable the "thread" feature.
+origin-thread = ["memoffset", "rustix/runtime", "origin-program"]
 
 # Use origin's implementation of signal handle registrtion.
-origin-signal = ["rustix/runtime", "signal"]
+#
+# To use threads, it's also necessary to enable the "signal" feature.
+origin-signal = ["rustix/runtime"]
 
 # Use origin's `_start` definition.
 origin-start = ["rustix/use-explicitly-provided-auxv", "rustix/runtime", "origin-program"]
@@ -96,13 +100,10 @@ max_level_off = ["log/max_level_off"]
 
 # Enable features which depend on the Rust global allocator, such as functions
 # that return owned strings or `Vec`s.
-alloc = ["rustix/alloc"]
+alloc = ["rustix/alloc", "smallvec"]
 
 # Enable support for threads.
-#
-# Origin's threads support currently depends on dynamic allocation, so it
-# pulls in the "alloc" feature.
-thread = ["alloc", "rustix/thread", "rustix/mm", "param", "rustix/process", "rustix/runtime", "rustix-futex-sync"]
+thread = ["rustix/thread", "rustix/mm", "param", "rustix/process", "rustix/runtime", "rustix-futex-sync"]
 
 # Enable support for signal handlers.
 signal = ["rustix/runtime"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ rustix = { version = "0.38.26", default-features = false }
 bitflags = { version = "2.4.0", default-features = false }
 memoffset = { version = "0.9.0", optional = true }
 log = { version = "0.4.14", default-features = false, optional = true }
-rustix-futex-sync = "0.2.1"
+rustix-futex-sync = { version = "0.2.1", optional = true }
 
 # Optional logging backends for use with "origin-program". You can use any
 # external logger, but using these features allows origin to initialize the
@@ -102,7 +102,7 @@ alloc = ["rustix/alloc"]
 #
 # Origin's threads support currently depends on dynamic allocation, so it
 # pulls in the "alloc" feature.
-thread = ["alloc", "rustix/thread", "rustix/mm", "param", "rustix/process", "rustix/runtime"]
+thread = ["alloc", "rustix/thread", "rustix/mm", "param", "rustix/process", "rustix/runtime", "rustix-futex-sync"]
 
 # Enable support for signal handlers.
 signal = ["rustix/runtime"]

--- a/example-crates/external-start/Cargo.toml
+++ b/example-crates/external-start/Cargo.toml
@@ -7,7 +7,7 @@ publish = false
 [dependencies]
 # Origin can be depended on just like any other crate. For no_std, disable
 # the default features, and the desired features.
-origin = { path = "../..", default-features = false, features = ["origin-thread", "external-start"] }
+origin = { path = "../..", default-features = false, features = ["origin-thread", "external-start", "thread", "alloc"] }
 
 # Ensure that libc gets linked.
 libc = { version = "0.2", default-features = false }

--- a/example-crates/no-std/Cargo.toml
+++ b/example-crates/no-std/Cargo.toml
@@ -7,7 +7,7 @@ publish = false
 [dependencies]
 # Origin can be depended on just like any other crate. For no_std, disable
 # the default features. And enable "libc" to enable the libc implementations.
-origin = { path = "../..", default-features = false, features = ["libc", "thread"] }
+origin = { path = "../..", default-features = false, features = ["libc", "thread", "alloc"] }
 
 # Crates to help writing no_std code.
 atomic-dbg = { version = "0.1.8", default-features = false }

--- a/example-crates/origin-start-lto/Cargo.toml
+++ b/example-crates/origin-start-lto/Cargo.toml
@@ -7,7 +7,7 @@ publish = false
 [dependencies]
 # Origin can be depended on just like any other crate. For no_std, disable
 # the default features, and the desired features.
-origin = { path = "../..", default-features = false, features = ["origin-thread", "origin-start"] }
+origin = { path = "../..", default-features = false, features = ["origin-thread", "origin-start", "thread", "alloc"] }
 
 # Crates to help writing no_std code.
 atomic-dbg = { version = "0.1.8", default-features = false }

--- a/example-crates/origin-start/Cargo.toml
+++ b/example-crates/origin-start/Cargo.toml
@@ -7,7 +7,7 @@ publish = false
 [dependencies]
 # Origin can be depended on just like any other crate. For no_std, disable
 # the default features, and the desired features.
-origin = { path = "../..", default-features = false, features = ["origin-thread", "origin-start"] }
+origin = { path = "../..", default-features = false, features = ["origin-thread", "origin-start", "thread", "alloc"] }
 
 # Crates to help writing no_std code.
 atomic-dbg = { version = "0.1.8", default-features = false }

--- a/src/arch/aarch64.rs
+++ b/src/arch/aarch64.rs
@@ -6,7 +6,7 @@ use linux_raw_sys::general::__NR_rt_sigreturn;
 #[cfg(all(feature = "experimental-relocate", feature = "origin-start"))]
 #[cfg(relocation_model = "pic")]
 use linux_raw_sys::general::{__NR_mprotect, PROT_READ};
-#[cfg(feature = "origin-thread")]
+#[cfg(all(feature = "origin-thread", feature = "thread"))]
 use {
     core::ffi::c_void,
     linux_raw_sys::general::{__NR_clone, __NR_exit, __NR_munmap},
@@ -130,7 +130,7 @@ pub(super) unsafe fn relocation_mprotect_readonly(ptr: usize, len: usize) {
 }
 
 /// The required alignment for the stack pointer.
-#[cfg(feature = "origin-thread")]
+#[cfg(all(feature = "origin-thread", feature = "thread"))]
 pub(super) const STACK_ALIGNMENT: usize = 16;
 
 /// A wrapper around the Linux `clone` system call.
@@ -138,7 +138,7 @@ pub(super) const STACK_ALIGNMENT: usize = 16;
 /// This can't be implemented in `rustix` because the child starts executing at
 /// the same point as the parent and we need to use inline asm to have the
 /// child jump to our new-thread entrypoint.
-#[cfg(feature = "origin-thread")]
+#[cfg(all(feature = "origin-thread", feature = "thread"))]
 #[inline]
 pub(super) unsafe fn clone(
     flags: u32,
@@ -180,7 +180,7 @@ pub(super) unsafe fn clone(
 }
 
 /// Write a value to the platform thread-pointer register.
-#[cfg(feature = "origin-thread")]
+#[cfg(all(feature = "origin-thread", feature = "thread"))]
 #[inline]
 pub(super) unsafe fn set_thread_pointer(ptr: *mut c_void) {
     asm!("msr tpidr_el0, {}", in(reg) ptr);
@@ -200,12 +200,12 @@ pub(super) fn thread_pointer() -> *mut c_void {
 }
 
 /// TLS data starts at the location pointed to by the thread pointer.
-#[cfg(feature = "origin-thread")]
+#[cfg(all(feature = "origin-thread", feature = "thread"))]
 pub(super) const TLS_OFFSET: usize = 0;
 
 /// `munmap` the current thread, then carefully exit the thread without
 /// touching the deallocated stack.
-#[cfg(feature = "origin-thread")]
+#[cfg(all(feature = "origin-thread", feature = "thread"))]
 #[inline]
 pub(super) unsafe fn munmap_and_exit_thread(map_addr: *mut c_void, map_len: usize) -> ! {
     asm!(

--- a/src/arch/arm.rs
+++ b/src/arch/arm.rs
@@ -6,7 +6,7 @@ use core::arch::asm;
 use linux_raw_sys::general::{__NR_mprotect, PROT_READ};
 #[cfg(feature = "origin-signal")]
 use linux_raw_sys::general::{__NR_rt_sigreturn, __NR_sigreturn};
-#[cfg(feature = "origin-thread")]
+#[cfg(all(feature = "origin-thread", feature = "thread"))]
 use {
     core::ffi::c_void,
     linux_raw_sys::general::{__NR_clone, __NR_exit, __NR_munmap},
@@ -130,7 +130,7 @@ pub(super) unsafe fn relocation_mprotect_readonly(ptr: usize, len: usize) {
 }
 
 /// The required alignment for the stack pointer.
-#[cfg(feature = "origin-thread")]
+#[cfg(all(feature = "origin-thread", feature = "thread"))]
 pub(super) const STACK_ALIGNMENT: usize = 4;
 
 /// A wrapper around the Linux `clone` system call.
@@ -138,7 +138,7 @@ pub(super) const STACK_ALIGNMENT: usize = 4;
 /// This can't be implemented in `rustix` because the child starts executing at
 /// the same point as the parent and we need to use inline asm to have the
 /// child jump to our new-thread entrypoint.
-#[cfg(feature = "origin-thread")]
+#[cfg(all(feature = "origin-thread", feature = "thread"))]
 #[inline]
 pub(super) unsafe fn clone(
     flags: u32,
@@ -181,7 +181,7 @@ pub(super) unsafe fn clone(
 }
 
 /// Write a value to the platform thread-pointer register.
-#[cfg(feature = "origin-thread")]
+#[cfg(all(feature = "origin-thread", feature = "thread"))]
 #[inline]
 pub(super) unsafe fn set_thread_pointer(ptr: *mut c_void) {
     rustix::runtime::arm_set_tls(ptr).expect("arm_set_tls");
@@ -189,7 +189,7 @@ pub(super) unsafe fn set_thread_pointer(ptr: *mut c_void) {
 }
 
 /// Read the value of the platform thread-pointer register.
-#[cfg(feature = "origin-thread")]
+#[cfg(all(feature = "origin-thread", feature = "thread"))]
 #[inline]
 pub(super) fn thread_pointer() -> *mut c_void {
     let ptr;
@@ -201,12 +201,12 @@ pub(super) fn thread_pointer() -> *mut c_void {
 }
 
 /// TLS data starts at the location pointed to by the thread pointer.
-#[cfg(feature = "origin-thread")]
+#[cfg(all(feature = "origin-thread", feature = "thread"))]
 pub(super) const TLS_OFFSET: usize = 0;
 
 /// `munmap` the current thread, then carefully exit the thread without
 /// touching the deallocated stack.
-#[cfg(feature = "origin-thread")]
+#[cfg(all(feature = "origin-thread", feature = "thread"))]
 #[inline]
 pub(super) unsafe fn munmap_and_exit_thread(map_addr: *mut c_void, map_len: usize) -> ! {
     asm!(

--- a/src/arch/riscv64.rs
+++ b/src/arch/riscv64.rs
@@ -1,11 +1,14 @@
 //! Architecture-specific assembly code.
 
-#[cfg(any(feature = "origin-thread", feature = "origin-start"))]
+#[cfg(any(
+    all(feature = "origin-thread", feature = "thread"),
+    feature = "origin-start"
+))]
 use core::arch::asm;
 #[cfg(all(feature = "experimental-relocate", feature = "origin-start"))]
 #[cfg(relocation_model = "pic")]
 use linux_raw_sys::general::{__NR_mprotect, PROT_READ};
-#[cfg(feature = "origin-thread")]
+#[cfg(all(feature = "origin-thread", feature = "thread"))]
 use {
     core::ffi::c_void,
     linux_raw_sys::general::{__NR_clone, __NR_exit, __NR_munmap},
@@ -130,7 +133,7 @@ pub(super) unsafe fn relocation_mprotect_readonly(ptr: usize, len: usize) {
 }
 
 /// The required alignment for the stack pointer.
-#[cfg(feature = "origin-thread")]
+#[cfg(all(feature = "origin-thread", feature = "thread"))]
 pub(super) const STACK_ALIGNMENT: usize = 16;
 
 /// A wrapper around the Linux `clone` system call.
@@ -138,7 +141,7 @@ pub(super) const STACK_ALIGNMENT: usize = 16;
 /// This can't be implemented in `rustix` because the child starts executing at
 /// the same point as the parent and we need to use inline asm to have the
 /// child jump to our new-thread entrypoint.
-#[cfg(feature = "origin-thread")]
+#[cfg(all(feature = "origin-thread", feature = "thread"))]
 #[inline]
 pub(super) unsafe fn clone(
     flags: u32,
@@ -180,7 +183,7 @@ pub(super) unsafe fn clone(
 }
 
 /// Write a value to the platform thread-pointer register.
-#[cfg(feature = "origin-thread")]
+#[cfg(all(feature = "origin-thread", feature = "thread"))]
 #[inline]
 pub(super) unsafe fn set_thread_pointer(ptr: *mut c_void) {
     asm!("mv tp, {}", in(reg) ptr);
@@ -188,7 +191,7 @@ pub(super) unsafe fn set_thread_pointer(ptr: *mut c_void) {
 }
 
 /// Read the value of the platform thread-pointer register.
-#[cfg(feature = "origin-thread")]
+#[cfg(all(feature = "origin-thread", feature = "thread"))]
 #[inline]
 pub(super) fn thread_pointer() -> *mut c_void {
     let ptr;
@@ -201,12 +204,12 @@ pub(super) fn thread_pointer() -> *mut c_void {
 
 /// TLS data starts 0x800 bytes below the location pointed to by the thread
 /// pointer.
-#[cfg(feature = "origin-thread")]
+#[cfg(all(feature = "origin-thread", feature = "thread"))]
 pub(super) const TLS_OFFSET: usize = 0x800;
 
 /// `munmap` the current thread, then carefully exit the thread without
 /// touching the deallocated stack.
-#[cfg(feature = "origin-thread")]
+#[cfg(all(feature = "origin-thread", feature = "thread"))]
 #[inline]
 pub(super) unsafe fn munmap_and_exit_thread(map_addr: *mut c_void, map_len: usize) -> ! {
     asm!(

--- a/src/arch/x86.rs
+++ b/src/arch/x86.rs
@@ -6,7 +6,7 @@ use core::arch::asm;
 use linux_raw_sys::general::{__NR_mprotect, PROT_READ};
 #[cfg(feature = "origin-signal")]
 use linux_raw_sys::general::{__NR_rt_sigreturn, __NR_sigreturn};
-#[cfg(feature = "origin-thread")]
+#[cfg(all(feature = "origin-thread", feature = "thread"))]
 use {
     core::ffi::c_void,
     core::ptr::invalid_mut,
@@ -135,7 +135,7 @@ pub(super) unsafe fn relocation_mprotect_readonly(ptr: usize, len: usize) {
 }
 
 /// The required alignment for the stack pointer.
-#[cfg(feature = "origin-thread")]
+#[cfg(all(feature = "origin-thread", feature = "thread"))]
 pub(super) const STACK_ALIGNMENT: usize = 16;
 
 /// A wrapper around the Linux `clone` system call.
@@ -143,7 +143,7 @@ pub(super) const STACK_ALIGNMENT: usize = 16;
 /// This can't be implemented in `rustix` because the child starts executing at
 /// the same point as the parent and we need to use inline asm to have the
 /// child jump to our new-thread entrypoint.
-#[cfg(feature = "origin-thread")]
+#[cfg(all(feature = "origin-thread", feature = "thread"))]
 #[inline]
 pub(super) unsafe fn clone(
     flags: u32,
@@ -231,7 +231,7 @@ pub(super) unsafe fn clone(
 }
 
 /// Write a value to the platform thread-pointer register.
-#[cfg(feature = "origin-thread")]
+#[cfg(all(feature = "origin-thread", feature = "thread"))]
 #[inline]
 pub(super) unsafe fn set_thread_pointer(ptr: *mut c_void) {
     let mut user_desc = rustix::runtime::UserDesc {
@@ -255,7 +255,7 @@ pub(super) unsafe fn set_thread_pointer(ptr: *mut c_void) {
 }
 
 /// Read the value of the platform thread-pointer register.
-#[cfg(feature = "origin-thread")]
+#[cfg(all(feature = "origin-thread", feature = "thread"))]
 #[inline]
 pub(super) fn thread_pointer() -> *mut c_void {
     let ptr;
@@ -270,12 +270,12 @@ pub(super) fn thread_pointer() -> *mut c_void {
 }
 
 /// TLS data ends at the location pointed to by the thread pointer.
-#[cfg(feature = "origin-thread")]
+#[cfg(all(feature = "origin-thread", feature = "thread"))]
 pub(super) const TLS_OFFSET: usize = 0;
 
 /// `munmap` the current thread, then carefully exit the thread without
 /// touching the deallocated stack.
-#[cfg(feature = "origin-thread")]
+#[cfg(all(feature = "origin-thread", feature = "thread"))]
 #[inline]
 pub(super) unsafe fn munmap_and_exit_thread(map_addr: *mut c_void, map_len: usize) -> ! {
     asm!(

--- a/src/program.rs
+++ b/src/program.rs
@@ -27,7 +27,7 @@
 //! with origin's goal of providing Rust-idiomatic interfaces, however it does
 //! mean that origin can avoid doing any work that users might not need.
 
-#[cfg(feature = "origin-thread")]
+#[cfg(all(feature = "origin-thread", feature = "thread"))]
 use crate::thread;
 #[cfg(feature = "alloc")]
 use alloc::boxed::Box;
@@ -208,11 +208,11 @@ unsafe fn init_runtime(mem: *mut usize, envp: *mut *mut u8) {
     rustix::param::init(envp);
 
     // Read the program headers and extract the TLS info.
-    #[cfg(feature = "origin-thread")]
+    #[cfg(all(feature = "origin-thread", feature = "thread"))]
     thread::initialize_startup_info();
 
     // Initialize the main thread.
-    #[cfg(feature = "origin-thread")]
+    #[cfg(all(feature = "origin-thread", feature = "thread"))]
     thread::initialize_main(mem.cast());
 }
 
@@ -289,7 +289,7 @@ pub fn at_exit(func: Box<dyn FnOnce() + Send>) {
 /// `.fini_array` section, and exit the program.
 pub fn exit(status: c_int) -> ! {
     // Call functions registered with `at_thread_exit`.
-    #[cfg(all(feature = "thread", feature = "origin-program"))]
+    #[cfg(all(feature = "alloc", feature = "thread", feature = "origin-program"))]
     crate::thread::call_dtors(crate::thread::current());
 
     // Call all the registered functions, in reverse order. Leave `DTORS`

--- a/src/program.rs
+++ b/src/program.rs
@@ -34,7 +34,7 @@ use alloc::boxed::Box;
 #[cfg(not(feature = "origin-program"))]
 use core::ptr::null_mut;
 use linux_raw_sys::ctypes::c_int;
-#[cfg(all(feature = "alloc", feature = "origin-program"))]
+#[cfg(all(feature = "alloc", feature = "origin-program", feature = "thread"))]
 use rustix_futex_sync::Mutex;
 
 #[cfg(all(
@@ -222,9 +222,24 @@ unsafe fn init_runtime(mem: *mut usize, envp: *mut *mut u8) {
 /// `SmallVec` to ensure we can register that many without allocating.
 ///
 /// [POSIX guarantees]: https://pubs.opengroup.org/onlinepubs/9699919799/functions/atexit.html
-#[cfg(all(feature = "alloc", feature = "origin-program"))]
+#[cfg(all(feature = "alloc", feature = "origin-program", feature = "thread"))]
 static DTORS: Mutex<smallvec::SmallVec<[Box<dyn FnOnce() + Send>; 32]>> =
     Mutex::new(smallvec::SmallVec::new_const());
+
+/// A type for `DTORS` in the single-threaded case that we can mark as `Sync`.
+#[cfg(all(feature = "alloc", feature = "origin-program", not(feature = "thread")))]
+struct Dtors(smallvec::SmallVec<[Box<dyn FnOnce() + Send>; 32]>);
+
+/// SAFETY: With `feature = "origin-program"`, we can assume that Origin is
+/// responsible for creating all threads in the program, and with
+/// `not(feature = "thread")` mode, Origin can't create any new threads, so we
+/// don't need to synchronize.
+#[cfg(all(feature = "alloc", feature = "origin-program", not(feature = "thread")))]
+unsafe impl Sync for Dtors {}
+
+/// The single-threaded version of `DTORS`.
+#[cfg(all(feature = "alloc", feature = "origin-program", not(feature = "thread")))]
+static mut DTORS: Dtors = Dtors(smallvec::SmallVec::new_const());
 
 /// Register a function to be called when [`exit`] is called.
 ///
@@ -237,8 +252,13 @@ static DTORS: Mutex<smallvec::SmallVec<[Box<dyn FnOnce() + Send>; 32]>> =
 pub fn at_exit(func: Box<dyn FnOnce() + Send>) {
     #[cfg(feature = "origin-program")]
     {
-        let mut funcs = DTORS.lock();
-        funcs.push(func);
+        #[cfg(feature = "thread")]
+        let mut dtors = DTORS.lock();
+        // SAFETY: See the safety comments on the `unsafe impl Sync for Dtors`.
+        #[cfg(not(feature = "thread"))]
+        let dtors = unsafe { &mut DTORS.0 };
+
+        dtors.push(func);
     }
 
     #[cfg(not(feature = "origin-program"))]
@@ -277,12 +297,17 @@ pub fn exit(status: c_int) -> ! {
     // to the end of the list.
     #[cfg(all(feature = "alloc", feature = "origin-program"))]
     loop {
+        #[cfg(feature = "thread")]
         let mut dtors = DTORS.lock();
-        if let Some(dtor) = dtors.pop() {
+        // SAFETY: See the safety comments on the `unsafe impl Sync for Dtors`.
+        #[cfg(not(feature = "thread"))]
+        let dtors = unsafe { &mut DTORS.0 };
+
+        if let Some(func) = dtors.pop() {
             #[cfg(feature = "log")]
             log::trace!("Calling `at_exit`-registered function");
 
-            dtor();
+            func();
         } else {
             break;
         }

--- a/test-crates/origin-start/Cargo.toml
+++ b/test-crates/origin-start/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 publish = false
 
 [dependencies]
-origin = { path = "../..", default-features = false, features = ["origin-thread", "origin-start"] }
+origin = { path = "../..", default-features = false, features = ["origin-thread", "origin-start", "thread", "alloc"] }
 atomic-dbg = { version = "0.1.8", default-features = false }
 rustix-dlmalloc = { version = "0.1.0", features = ["global"] }
 compiler_builtins = { version = "0.1.101", features = ["mem"] }


### PR DESCRIPTION
Avoid depending on `rustix-futex-sync` if support for threads is not enabled.