### PR TITLE
Reduce the complexity around all possible feature combinations

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -66,12 +66,12 @@ rustc-dep-of-std = [
 ]
 
 # Use origin's implementation of program startup and shutdown.
-origin-program = []
+origin-program = ["rustix/use-explicitly-provided-auxv", "rustix/runtime"]
 
 # Use origin's implementation of thread startup and shutdown.
 #
 # To use threads, it's also necessary to enable the "thread" feature.
-origin-thread = ["memoffset", "rustix/runtime", "origin-program"]
+origin-thread = ["memoffset", "origin-program"]
 
 # Use origin's implementation of signal handle registrtion.
 #
@@ -79,12 +79,12 @@ origin-thread = ["memoffset", "rustix/runtime", "origin-program"]
 origin-signal = ["rustix/runtime"]
 
 # Use origin's `_start` definition.
-origin-start = ["rustix/use-explicitly-provided-auxv", "rustix/runtime", "origin-program"]
+origin-start = ["origin-program"]
 
 # Don't use origin's `_start` definition, but export a `start` function which
 # is meant to be run very early in program startup and passed a pointer to
 # the initial stack. Don't enable this when enabling "origin-start".
-external-start = ["rustix/use-explicitly-provided-auxv", "rustix/runtime", "origin-program"]
+external-start = ["origin-program"]
 
 # The loggers depend on a `.init_array` entry to initialize themselves, and
 # `env_logger` needs it so that `c-scape` can initialize environment variables

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -65,9 +65,6 @@ rustc-dep-of-std = [
     "dep:compiler_builtins",
 ]
 
-# Enable the `set_current_id_after_a_fork` function.
-set_thread_id = []
-
 # Use origin's implementation of program startup and shutdown.
 origin-program = []
 

--- a/src/program.rs
+++ b/src/program.rs
@@ -38,7 +38,7 @@ use linux_raw_sys::ctypes::c_int;
 use rustix_futex_sync::Mutex;
 
 #[cfg(all(
-    feature = "program-start",
+    feature = "origin-program",
     not(any(feature = "origin-start", feature = "external-start"))
 ))]
 compile_error!("\"origin-program\" depends on either \"origin-start\" or \"external-start\".");

--- a/src/thread/libc.rs
+++ b/src/thread/libc.rs
@@ -196,7 +196,6 @@ pub fn current_id() -> ThreadId {
 /// This must only be called immediately after a `fork` before any other
 /// threads are created. `tid` must be the same value as what [`gettid`] would
 /// return.
-#[cfg(feature = "set_thread_id")]
 #[doc(hidden)]
 #[inline]
 pub unsafe fn set_current_id_after_a_fork(tid: ThreadId) {

--- a/src/thread/linux_raw.rs
+++ b/src/thread/linux_raw.rs
@@ -989,8 +989,6 @@ pub fn current_id() -> ThreadId {
 /// This must only be called immediately after a `fork` before any other
 /// threads are created. `tid` must be the same value as what [`gettid`] would
 /// return.
-#[cfg(feature = "set_thread_id")]
-#[cfg_attr(doc_cfg, doc(cfg(feature = "set_thread_id")))]
 #[doc(hidden)]
 #[inline]
 pub unsafe fn set_current_id_after_a_fork(tid: ThreadId) {


### PR DESCRIPTION
This folds a couple of features that I don't think add much value into whichever feature it makes sense. Also unconditionally call `rustix::param::init` when the origin-program feature is enabled. And finally fix a compile time assertion where a feature rename was missed.