### PR TITLE
Support acting as startup code of a dynamic linker

### DIFF
--- a/example-crates/origin-start-dynamic-linker/Cargo.toml
+++ b/example-crates/origin-start-dynamic-linker/Cargo.toml
@@ -1,0 +1,21 @@
+[package]
+name = "origin-start"
+version = "0.0.0"
+edition = "2021"
+publish = false
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+# Origin can be depended on just like any other crate. For no_std, disable
+# the default features, and the desired features.
+origin = { path = "../..", default-features = false, features = ["origin-thread", "origin-start", "thread", "alloc", "experimental-relocate"] }
+
+# Crates to help writing no_std code.
+atomic-dbg = { version = "0.1.8", default-features = false }
+rustix-dlmalloc = { version = "0.1.0", features = ["global"] }
+compiler_builtins = { version = "0.1.101", features = ["mem"] }
+
+# This is just an example crate, and not part of the origin workspace.
+[workspace]

--- a/example-crates/origin-start-dynamic-linker/README.md
+++ b/example-crates/origin-start-dynamic-linker/README.md
@@ -1,0 +1,5 @@
+This crate demonstrates the use of origin as a plain library API using
+`#![no_std]` and `#![no_main]`.
+
+This version uses `-nostartfiles` and origin is in control from the very
+beginning. This uses origin in an "origin-start" configuration.

--- a/example-crates/origin-start-dynamic-linker/build.rs
+++ b/example-crates/origin-start-dynamic-linker/build.rs
@@ -1,0 +1,11 @@
+fn main() {
+    // Pass -nostartfiles to the linker. In the future this could be obviated
+    // by a `no_entry` feature: <https://github.com/rust-lang/rfcs/pull/2735>
+    println!("cargo:rustc-link-arg=-nostartfiles");
+    // Set entry point for the dynamic library, making it capable of being
+    // executed like an executable and being used as dynamic linker.
+    println!("cargo:rustc-link-arg=-Wl,-e,_start");
+    // Prevent non R_RELATIVE relocations by forcing all references to global
+    // symbols to be resolved locally.
+    println!("cargo:rustc-link-arg=-Wl,-Bsymbolic");
+}

--- a/example-crates/origin-start-dynamic-linker/src/lib.rs
+++ b/example-crates/origin-start-dynamic-linker/src/lib.rs
@@ -1,0 +1,57 @@
+//! A simple example acting as dynamic linker using `no_std` and `no_main` and origin's start.
+
+#![no_std]
+#![no_main]
+#![allow(internal_features)]
+#![feature(lang_items)]
+#![feature(core_intrinsics)]
+
+extern crate alloc;
+extern crate compiler_builtins;
+
+use alloc::boxed::Box;
+use atomic_dbg::{dbg, eprintln};
+use origin::{program, thread};
+
+#[panic_handler]
+fn panic(panic: &core::panic::PanicInfo<'_>) -> ! {
+    dbg!(panic);
+    core::intrinsics::abort();
+}
+
+#[lang = "eh_personality"]
+extern "C" fn eh_personality() {}
+
+#[global_allocator]
+static GLOBAL_ALLOCATOR: rustix_dlmalloc::GlobalDlmalloc = rustix_dlmalloc::GlobalDlmalloc;
+
+#[no_mangle]
+unsafe fn origin_main(_argc: usize, _argv: *mut *mut u8, _envp: *mut *mut u8) -> i32 {
+    eprintln!("Hello from main thread");
+
+    program::at_exit(Box::new(|| {
+        eprintln!("Hello from an `program::at_exit` handler")
+    }));
+    thread::at_exit(Box::new(|| {
+        eprintln!("Hello from a main-thread `thread::at_exit` handler")
+    }));
+
+    let thread = thread::create(
+        |_args| {
+            eprintln!("Hello from child thread");
+            thread::at_exit(Box::new(|| {
+                eprintln!("Hello from child thread's `thread::at_exit` handler")
+            }));
+            None
+        },
+        &[],
+        thread::default_stack_size(),
+        thread::default_guard_size(),
+    )
+    .unwrap();
+
+    thread::join(thread);
+
+    eprintln!("Goodbye from main");
+    program::exit(0);
+}

--- a/src/arch/aarch64.rs
+++ b/src/arch/aarch64.rs
@@ -30,6 +30,11 @@ pub(super) unsafe extern "C" fn _start() -> ! {
     // already null.
     asm!(
         "mov x0, sp",   // Pass the incoming `sp` as the arg to `entry`.
+        // Pass the address of `_DYNAMIC` as arg to `entry`
+        ".weak _DYNAMIC",
+        ".hidden _DYNAMIC",
+        "adrp x1, _DYNAMIC",
+        "add x1, x1, #:lo12:_DYNAMIC",
         "mov x30, xzr", // Set the return address to zero.
         "b {entry}",    // Jump to `entry`.
         entry = sym super::program::entry,

--- a/src/arch/aarch64.rs
+++ b/src/arch/aarch64.rs
@@ -1,6 +1,9 @@
 //! Architecture-specific assembly code.
 
 use core::arch::asm;
+#[cfg(all(feature = "experimental-relocate", feature = "origin-start"))]
+#[cfg(relocation_model = "pic")]
+use linux_raw_sys::elf::Elf_Dyn;
 #[cfg(feature = "origin-signal")]
 use linux_raw_sys::general::__NR_rt_sigreturn;
 #[cfg(all(feature = "experimental-relocate", feature = "origin-start"))]
@@ -30,16 +33,28 @@ pub(super) unsafe extern "C" fn _start() -> ! {
     // already null.
     asm!(
         "mov x0, sp",   // Pass the incoming `sp` as the arg to `entry`.
-        // Pass the address of `_DYNAMIC` as arg to `entry`
-        ".weak _DYNAMIC",
-        ".hidden _DYNAMIC",
-        "adrp x1, _DYNAMIC",
-        "add x1, x1, #:lo12:_DYNAMIC",
         "mov x30, xzr", // Set the return address to zero.
         "b {entry}",    // Jump to `entry`.
         entry = sym super::program::entry,
         options(noreturn),
     )
+}
+
+/// Compute the dynamic address of `_DYNAMIC`.
+#[cfg(all(feature = "experimental-relocate", feature = "origin-start"))]
+#[cfg(relocation_model = "pic")]
+pub(super) fn dynamic_table_addr() -> *const Elf_Dyn {
+    let addr;
+    unsafe {
+        asm!(
+            ".weak _DYNAMIC",
+            ".hidden _DYNAMIC",
+            "adrp x0, _DYNAMIC",
+            "add x0, x0, #:lo12:_DYNAMIC",
+            out("x0") addr,
+        );
+    }
+    addr
 }
 
 /// Perform a single load operation, outside the Rust memory model.

--- a/src/arch/arm.rs
+++ b/src/arch/arm.rs
@@ -31,7 +31,14 @@ pub(super) unsafe extern "C" fn _start() -> ! {
     asm!(
         "mov r0, sp",   // Pass the incoming `sp` as the arg to `entry`.
         "mov lr, #0",   // Set the return address to zero.
+        // Pass the address of `_DYNAMIC` as arg to `entry`
+        "ldr r1, 2f",
+        "1: add r1, pc, r1",
         "b {entry}",    // Jump to `entry`.
+        ".weak _DYNAMIC",
+        ".hidden _DYNAMIC",
+        ".align 2",
+        "2:	.word _DYNAMIC-1b+8",
         entry = sym super::program::entry,
         options(noreturn),
     )

--- a/src/arch/arm.rs
+++ b/src/arch/arm.rs
@@ -3,6 +3,9 @@
 use core::arch::asm;
 #[cfg(all(feature = "experimental-relocate", feature = "origin-start"))]
 #[cfg(relocation_model = "pic")]
+use linux_raw_sys::elf::Elf_Dyn;
+#[cfg(all(feature = "experimental-relocate", feature = "origin-start"))]
+#[cfg(relocation_model = "pic")]
 use linux_raw_sys::general::{__NR_mprotect, PROT_READ};
 #[cfg(feature = "origin-signal")]
 use linux_raw_sys::general::{__NR_rt_sigreturn, __NR_sigreturn};
@@ -31,17 +34,31 @@ pub(super) unsafe extern "C" fn _start() -> ! {
     asm!(
         "mov r0, sp",   // Pass the incoming `sp` as the arg to `entry`.
         "mov lr, #0",   // Set the return address to zero.
-        // Pass the address of `_DYNAMIC` as arg to `entry`
-        "ldr r1, 2f",
-        "1: add r1, pc, r1",
         "b {entry}",    // Jump to `entry`.
-        ".weak _DYNAMIC",
-        ".hidden _DYNAMIC",
-        ".align 2",
-        "2:	.word _DYNAMIC-1b+8",
         entry = sym super::program::entry,
         options(noreturn),
     )
+}
+
+/// Compute the dynamic address of `_DYNAMIC`.
+#[cfg(all(feature = "experimental-relocate", feature = "origin-start"))]
+#[cfg(relocation_model = "pic")]
+pub(super) fn dynamic_table_addr() -> *const Elf_Dyn {
+    let addr;
+    unsafe {
+        asm!(
+            ".weak _DYNAMIC",
+            ".hidden _DYNAMIC",
+            "ldr r0, 2f",
+            "1: add r0, pc, r0",
+            "b 3f",
+            ".align 2",
+            "2: .word _DYNAMIC-(1b+8)",
+            "3:",
+            out("r0") addr,
+        );
+    }
+    addr
 }
 
 /// Perform a single load operation, outside the Rust memory model.

--- a/src/arch/riscv64.rs
+++ b/src/arch/riscv64.rs
@@ -32,6 +32,10 @@ pub(super) unsafe extern "C" fn _start() -> ! {
     // already null.
     asm!(
         "mv a0, sp",    // Pass the incoming `sp` as the arg to `entry`.
+        ".weak _DYNAMIC",
+        ".hidden _DYNAMIC",
+        // Pass the address of `_DYNAMIC` as arg to `entry`
+        "lla a1, _DYNAMIC",
         "mv ra, zero",  // Set the return address to zero.
         "mv fp, zero",  // Set the frame address to zero.
         "tail {entry}", // Jump to `entry`.

--- a/src/arch/x86.rs
+++ b/src/arch/x86.rs
@@ -34,6 +34,9 @@ pub(super) unsafe extern "C" fn _start() -> ! {
         "push ebp",     // Pad for stack pointer alignment.
         "push ebp",     // Pad for stack pointer alignment.
         "push ebp",     // Pad for stack pointer alignment.
+        "push eax",
+        "call 1f",
+        "1:	add [esp], _DYNAMIC-1b",
         "push eax",     // Pass saved the incoming `esp` as the arg to `entry`.
         "push ebp",     // Set the return address to zero.
         "jmp {entry}",  // Jump to `entry`.

--- a/src/arch/x86.rs
+++ b/src/arch/x86.rs
@@ -49,18 +49,23 @@ pub(super) unsafe extern "C" fn _start() -> ! {
 #[cfg(all(feature = "experimental-relocate", feature = "origin-start"))]
 #[cfg(relocation_model = "pic")]
 pub(super) fn dynamic_table_addr() -> *const Elf_Dyn {
+    panic!("acting as dynamic linker not yet supported on 32-bit x86");
+    // FIXME somehow get LLVM to accept `add dword ptr [esp], _DYNAMIC-1b` or
+    // some other way to emit an `R_386_PC32` relocation against `_DYNAMIC`.
+    /*
     let addr;
     unsafe {
         asm!(
             ".weak _DYNAMIC",
             ".hidden _DYNAMIC",
             "call 1f",
-            "1: pop eax",
-            "add eax, _DYNAMIC-1b",
+            "1: add dword ptr [esp], _DYNAMIC-1b",
+            "pop eax",
             out("eax") addr,
         );
     }
     addr
+    */
 }
 
 /// Perform a single load operation, outside the Rust memory model.

--- a/src/arch/x86_64.rs
+++ b/src/arch/x86_64.rs
@@ -30,6 +30,10 @@ pub(super) unsafe extern "C" fn _start() -> ! {
     // already null.
     asm!(
         "mov rdi, rsp", // Pass the incoming `rsp` as the arg to `entry`.
+        ".weak _DYNAMIC",
+        ".hidden _DYNAMIC",
+        // Pass the address of `_DYNAMIC` as arg to `entry`
+        "lea rsi, [rip + _DYNAMIC]",
         "push rbp",     // Set the return address to zero.
         "jmp {entry}",  // Jump to `entry`.
         entry = sym super::program::entry,

--- a/src/arch/x86_64.rs
+++ b/src/arch/x86_64.rs
@@ -1,6 +1,9 @@
 //! Architecture-specific assembly code.
 
 use core::arch::asm;
+#[cfg(all(feature = "experimental-relocate", feature = "origin-start"))]
+#[cfg(relocation_model = "pic")]
+use linux_raw_sys::elf::Elf_Dyn;
 #[cfg(feature = "origin-signal")]
 use linux_raw_sys::general::__NR_rt_sigreturn;
 #[cfg(all(feature = "experimental-relocate", feature = "origin-start"))]
@@ -30,15 +33,27 @@ pub(super) unsafe extern "C" fn _start() -> ! {
     // already null.
     asm!(
         "mov rdi, rsp", // Pass the incoming `rsp` as the arg to `entry`.
-        ".weak _DYNAMIC",
-        ".hidden _DYNAMIC",
-        // Pass the address of `_DYNAMIC` as arg to `entry`
-        "lea rsi, [rip + _DYNAMIC]",
         "push rbp",     // Set the return address to zero.
         "jmp {entry}",  // Jump to `entry`.
         entry = sym super::program::entry,
         options(noreturn),
     )
+}
+
+/// Compute the dynamic address of `_DYNAMIC`.
+#[cfg(all(feature = "experimental-relocate", feature = "origin-start"))]
+#[cfg(relocation_model = "pic")]
+pub(super) fn dynamic_table_addr() -> *const Elf_Dyn {
+    let addr;
+    unsafe {
+        asm!(
+            ".weak _DYNAMIC",
+            ".hidden _DYNAMIC",
+            "lea rax, [rip + _DYNAMIC]",
+            out("rax") addr,
+        );
+    }
+    addr
 }
 
 /// Perform a single load operation, outside the Rust memory model.

--- a/src/program.rs
+++ b/src/program.rs
@@ -49,7 +49,7 @@ compile_error!("\"origin-program\" depends on either \"origin-start\" or \"exter
 ///
 /// `mem` must point to the stack as provided by the operating system.
 #[cfg(feature = "origin-program")]
-pub(super) unsafe extern "C" fn entry(mem: *mut usize) -> ! {
+pub(super) unsafe extern "C" fn entry(mem: *mut usize, dynv: *const usize) -> ! {
     // Do some basic precondition checks, to ensure that our assembly code did
     // what we expect it to do. These are debug-only, to keep the release-mode
     // startup code small and simple to disassemble and inspect.
@@ -91,7 +91,7 @@ pub(super) unsafe extern "C" fn entry(mem: *mut usize) -> ! {
     let (argc, argv, envp) = compute_args(mem);
 
     // Initialize program state before running any user code.
-    init_runtime(mem, envp);
+    init_runtime(mem, dynv, envp);
 
     // Call the functions registered via `.init_array`.
     #[cfg(feature = "init-array")]
@@ -162,7 +162,10 @@ pub(super) unsafe extern "C" fn entry(mem: *mut usize) -> ! {
 /// on the initial stack.
 #[cfg(feature = "external-start")]
 pub unsafe fn start(mem: *mut usize) -> ! {
-    entry(mem)
+    entry(
+        mem,
+        core::ptr::null(), // dummy as relocation isn't done here anyway
+    )
 }
 
 /// Compute `argc`, `argv`, and `envp`.
@@ -196,11 +199,11 @@ unsafe fn compute_args(mem: *mut usize) -> (i32, *mut *mut u8, *mut *mut u8) {
 /// must point to the incoming environment variables.
 #[cfg(feature = "origin-program")]
 #[allow(unused_variables)]
-unsafe fn init_runtime(mem: *mut usize, envp: *mut *mut u8) {
+unsafe fn init_runtime(mem: *mut usize, dynv: *const usize, envp: *mut *mut u8) {
     // Before doing anything else, perform dynamic relocations.
     #[cfg(all(feature = "experimental-relocate", feature = "origin-start"))]
     #[cfg(relocation_model = "pic")]
-    crate::relocate::relocate(envp);
+    crate::relocate::relocate(envp, dynv);
 
     // Explicitly initialize `rustix`. This is needed for things like
     // `page_size()` to work.

--- a/tests/example_crates.rs
+++ b/tests/example_crates.rs
@@ -138,6 +138,7 @@ fn example_crate_origin_start_crt_static_relocation_static_relocate() {
 
 /// Act as dynamic linker, run `relocate`.
 #[test]
+#[cfg_attr(target_arch = "x86", ignore)] // FIXME make it work on x86
 fn example_crate_origin_start_dynamic_linker() {
     use assert_cmd::Command;
 

--- a/tests/test_crates.rs
+++ b/tests/test_crates.rs
@@ -13,7 +13,7 @@ fn test_crate(
     stderr: &'static str,
     code: Option<i32>,
 ) {
-    utils::test_crate("test", name, args, envs, stdout, stderr, code);
+    utils::test_crate("test", "run", name, args, envs, stdout, stderr, code);
 }
 
 #[test]

--- a/tests/utils/mod.rs
+++ b/tests/utils/mod.rs
@@ -1,16 +1,6 @@
 #![allow(dead_code)]
 
-pub fn test_crate(
-    dir: &str,
-    name: &str,
-    args: &[&str],
-    envs: &[(&str, &str)],
-    stdout: &'static str,
-    stderr: &'static str,
-    code: Option<i32>,
-) {
-    use assert_cmd::Command;
-
+pub fn arch() -> String {
     #[cfg(target_arch = "x86_64")]
     let arch = "x86_64";
     #[cfg(target_arch = "aarch64")]
@@ -28,9 +18,24 @@ pub fn test_crate(
     #[cfg(all(target_env = "gnu", not(target_abi = "eabi")))]
     let env = "gnu";
 
+    format!("{arch}-unknown-linux-{env}")
+}
+
+pub fn test_crate(
+    dir: &str,
+    cmd: &str,
+    name: &str,
+    args: &[&str],
+    envs: &[(&str, &str)],
+    stdout: &'static str,
+    stderr: &'static str,
+    code: Option<i32>,
+) {
+    use assert_cmd::Command;
+
     let mut command = Command::new("cargo");
-    command.arg("run").arg("--quiet");
-    command.arg(&format!("--target={arch}-unknown-linux-{env}"));
+    command.arg(cmd).arg("--quiet");
+    command.arg(format!("--target={}", arch()));
     command.args(args);
     command.envs(envs.iter().copied());
     command.current_dir(format!("{dir}-crates/{name}"));


### PR DESCRIPTION
Previously this would result in the relocation code using the wrong offset as AT_PHDR points to the program headers of the main executable rather than of the dynamic linker itself.