### PR TITLE
Rename `invalid_mut` to `without_provenance_mut`

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "nightly-2023-12-19"
+channel = "nightly-2024-02-26"
 components = ["rustc", "cargo", "rust-std", "rust-src", "rustfmt"]

--- a/src/arch/x86.rs
+++ b/src/arch/x86.rs
@@ -9,7 +9,7 @@ use linux_raw_sys::general::{__NR_rt_sigreturn, __NR_sigreturn};
 #[cfg(all(feature = "origin-thread", feature = "thread"))]
 use {
     core::ffi::c_void,
-    core::ptr::invalid_mut,
+    core::ptr::without_provenance_mut,
     linux_raw_sys::general::{__NR_clone, __NR_exit, __NR_munmap},
     rustix::thread::RawPid,
 };
@@ -219,8 +219,8 @@ pub(super) unsafe fn clone(
         entry = sym super::thread::entry,
         inout("eax") &[
             newtls.cast::<c_void>().cast_mut(),
-            invalid_mut(__NR_clone as usize),
-            invalid_mut(num_args)
+            without_provenance_mut(__NR_clone as usize),
+            without_provenance_mut(num_args)
         ] => r0,
         in("ebx") flags,
         in("ecx") child_stack,

--- a/src/thread/libc.rs
+++ b/src/thread/libc.rs
@@ -3,7 +3,7 @@
 use alloc::boxed::Box;
 use core::ffi::c_void;
 use core::mem::{size_of, transmute, zeroed};
-use core::ptr::{from_exposed_addr_mut, without_provenance_mut, null_mut, NonNull};
+use core::ptr::{from_exposed_addr_mut, null_mut, without_provenance_mut, NonNull};
 use core::slice;
 use rustix::io;
 

--- a/src/thread/libc.rs
+++ b/src/thread/libc.rs
@@ -3,7 +3,7 @@
 use alloc::boxed::Box;
 use core::ffi::c_void;
 use core::mem::{size_of, transmute, zeroed};
-use core::ptr::{from_exposed_addr_mut, invalid_mut, null_mut, NonNull};
+use core::ptr::{from_exposed_addr_mut, without_provenance_mut, null_mut, NonNull};
 use core::slice;
 use rustix::io;
 
@@ -134,7 +134,7 @@ pub unsafe fn create(
             thread_arg_ptr.cast::<Option<NonNull<c_void>>>(),
             args.len() + 2,
         );
-        thread_args[0] = NonNull::new(invalid_mut(args.len()));
+        thread_args[0] = NonNull::new(without_provenance_mut(args.len()));
         thread_args[1] = NonNull::new(fn_ as _);
         thread_args[2..].copy_from_slice(args);
 

--- a/test-crates/origin-start/src/bin/tls.rs
+++ b/test-crates/origin-start/src/bin/tls.rs
@@ -120,7 +120,7 @@ fn check_eq(data: [*const u32; 3]) {
         assert_eq!(THREAD_LOCAL, data);
 
         // Check `THREAD_LOCAL` using a dynamic address.
-        let mut thread_local_addr: *mut [*const u32; 3] = &mut THREAD_LOCAL;
+        let mut thread_local_addr: *mut [*const u32; 3] = addr_of_mut!(THREAD_LOCAL);
         asm!("# {}", inout(reg) thread_local_addr, options(pure, nomem, nostack, preserves_flags));
         assert_eq!(*thread_local_addr, data);
     }


### PR DESCRIPTION
Plain rename made for newer nightlies.

Fixes https://github.com/sunfishcode/c-ward/pull/122 too.