### PR TITLE
Address `unexpected_cfgs` warnings

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -130,4 +130,3 @@ unstable-errno = ["thread"]
 
 [package.metadata.docs.rs]
 features = ["origin-thread", "origin-signal", "origin-start"]
-rustdoc-args = ["--cfg", "doc_cfg"]

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "nightly-2024-05-16"
+channel = "nightly-2024-05-20"
 components = ["rustc", "cargo", "rust-std", "rust-src", "rustfmt"]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,7 +1,7 @@
 #![doc = include_str!("../README.md")]
 #![deny(missing_docs)]
 #![cfg_attr(debug_assertions, allow(internal_features))]
-#![cfg_attr(doc_cfg, feature(doc_cfg))]
+#![cfg_attr(docsrs, feature(doc_cfg))]
 #![feature(asm_const)]
 #![feature(naked_functions)]
 #![cfg_attr(debug_assertions, feature(link_llvm_intrinsics))]
@@ -42,12 +42,12 @@ mod relocate;
 
 pub mod program;
 #[cfg(feature = "signal")]
-#[cfg_attr(doc_cfg, doc(cfg(feature = "signal")))]
+#[cfg_attr(docsrs, doc(cfg(feature = "signal")))]
 #[cfg_attr(feature = "origin-signal", path = "signal/linux_raw.rs")]
 #[cfg_attr(not(feature = "origin-signal"), path = "signal/libc.rs")]
 pub mod signal;
 #[cfg(feature = "thread")]
-#[cfg_attr(doc_cfg, doc(cfg(feature = "thread")))]
+#[cfg_attr(docsrs, doc(cfg(feature = "thread")))]
 #[cfg_attr(feature = "origin-thread", path = "thread/linux_raw.rs")]
 #[cfg_attr(not(feature = "origin-thread"), path = "thread/libc.rs")]
 pub mod thread;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,7 +9,6 @@
 #![feature(strict_provenance)]
 #![feature(exposed_provenance)]
 #![deny(fuzzy_provenance_casts, lossy_provenance_casts)]
-#![allow(unexpected_cfgs)]
 #![no_std]
 
 #[cfg(all(feature = "alloc", not(feature = "rustc-dep-of-std")))]

--- a/src/program.rs
+++ b/src/program.rs
@@ -248,7 +248,7 @@ static mut DTORS: Dtors = Dtors(smallvec::SmallVec::new_const());
 /// This arranges for `func` to be called, and passed `obj`, when the program
 /// exits.
 #[cfg(feature = "alloc")]
-#[cfg_attr(doc_cfg, doc(cfg(feature = "alloc")))]
+#[cfg_attr(docsrs, doc(cfg(feature = "alloc")))]
 pub fn at_exit(func: Box<dyn FnOnce() + Send>) {
     #[cfg(feature = "origin-program")]
     {

--- a/tests/utils/mod.rs
+++ b/tests/utils/mod.rs
@@ -11,8 +11,6 @@ pub fn arch() -> String {
     let arch = "i686";
     #[cfg(target_arch = "arm")]
     let arch = "armv5te";
-    #[cfg(target_env = "gnueabi")]
-    let env = "gnueabi";
     #[cfg(all(target_env = "gnu", target_abi = "eabi"))]
     let env = "gnueabi";
     #[cfg(all(target_env = "gnu", not(target_abi = "eabi")))]


### PR DESCRIPTION
This PR updates to the latest nightly and address all the `unexpected_cfgs` warnings, I could find.

Namely it:
 - uses `docsrs` instead of `doc_cfg`, since the former is standard
 - removes the `target_env = "gnueabi"` condition since no target uses it
 - and removes the allow since there are no other warnings

Fixes https://github.com/sunfishcode/origin/issues/114
r? @sunfishcode