### PR TITLE
Fix relocation to work on the latest Rust nightly.

### DIFF
--- a/src/arch/aarch64.rs
+++ b/src/arch/aarch64.rs
@@ -3,7 +3,7 @@
 use core::arch::asm;
 #[cfg(all(feature = "experimental-relocate", feature = "origin-start"))]
 #[cfg(relocation_model = "pic")]
-use linux_raw_sys::elf::Elf_Dyn;
+use linux_raw_sys::elf::{Elf_Dyn, Elf_Ehdr};
 #[cfg(feature = "origin-signal")]
 use linux_raw_sys::general::__NR_rt_sigreturn;
 #[cfg(all(feature = "experimental-relocate", feature = "origin-start"))]
@@ -49,9 +49,24 @@ pub(super) fn dynamic_table_addr() -> *const Elf_Dyn {
         asm!(
             ".weak _DYNAMIC",
             ".hidden _DYNAMIC",
-            "adrp x0, _DYNAMIC",
-            "add x0, x0, #:lo12:_DYNAMIC",
-            out("x0") addr,
+            "adrp {0}, _DYNAMIC",
+            "add {0}, {0}, :lo12:_DYNAMIC",
+            out(reg) addr
+        );
+    }
+    addr
+}
+
+/// Compute the dynamic address of `__ehdr_start`.
+#[cfg(all(feature = "experimental-relocate", feature = "origin-start"))]
+#[cfg(relocation_model = "pic")]
+pub(super) fn ehdr_addr() -> *const Elf_Ehdr {
+    let addr: *const Elf_Ehdr;
+    unsafe {
+        asm!(
+            "adrp {0}, __ehdr_start",
+            "add {0}, {0}, :lo12:__ehdr_start",
+            out(reg) addr
         );
     }
     addr

--- a/src/arch/riscv64.rs
+++ b/src/arch/riscv64.rs
@@ -7,7 +7,7 @@
 use core::arch::asm;
 #[cfg(all(feature = "experimental-relocate", feature = "origin-start"))]
 #[cfg(relocation_model = "pic")]
-use linux_raw_sys::elf::Elf_Dyn;
+use linux_raw_sys::elf::{Elf_Dyn, Elf_Ehdr};
 #[cfg(all(feature = "experimental-relocate", feature = "origin-start"))]
 #[cfg(relocation_model = "pic")]
 use linux_raw_sys::general::{__NR_mprotect, PROT_READ};
@@ -52,10 +52,23 @@ pub(super) fn dynamic_table_addr() -> *const Elf_Dyn {
         asm!(
             ".weak _DYNAMIC",
             ".hidden _DYNAMIC",
-            "lla a0, _DYNAMIC",
-            out("a0") addr,
+            "lla {}, _DYNAMIC",
+            out(reg) addr
         );
     }
+    addr
+}
+
+/// Compute the dynamic address of `__ehdr_start`.
+#[cfg(all(feature = "experimental-relocate", feature = "origin-start"))]
+#[cfg(relocation_model = "pic")]
+pub(super) fn ehdr_addr() -> *const Elf_Ehdr {
+    let addr: *const Elf_Ehdr;
+    unsafe {
+        asm!(
+            "lla {}, __ehdr_start",
+            out(reg) addr)
+    };
     addr
 }
 

--- a/src/arch/x86_64.rs
+++ b/src/arch/x86_64.rs
@@ -3,7 +3,7 @@
 use core::arch::asm;
 #[cfg(all(feature = "experimental-relocate", feature = "origin-start"))]
 #[cfg(relocation_model = "pic")]
-use linux_raw_sys::elf::Elf_Dyn;
+use linux_raw_sys::elf::{Elf_Dyn, Elf_Ehdr};
 #[cfg(feature = "origin-signal")]
 use linux_raw_sys::general::__NR_rt_sigreturn;
 #[cfg(all(feature = "experimental-relocate", feature = "origin-start"))]
@@ -49,8 +49,22 @@ pub(super) fn dynamic_table_addr() -> *const Elf_Dyn {
         asm!(
             ".weak _DYNAMIC",
             ".hidden _DYNAMIC",
-            "lea rax, [rip + _DYNAMIC]",
-            out("rax") addr,
+            "lea {}, [rip + _DYNAMIC]",
+            out(reg) addr
+        );
+    }
+    addr
+}
+
+/// Compute the dynamic address of `__ehdr_start`.
+#[cfg(all(feature = "experimental-relocate", feature = "origin-start"))]
+#[cfg(relocation_model = "pic")]
+pub(super) fn ehdr_addr() -> *const Elf_Ehdr {
+    let addr: *const Elf_Ehdr;
+    unsafe {
+        asm!(
+            "lea {}, [rip + __ehdr_start]",
+            out(reg) addr
         );
     }
     addr

--- a/tests/example_crates.rs
+++ b/tests/example_crates.rs
@@ -136,7 +136,6 @@ fn example_crate_origin_start_crt_static_relocation_static_relocate() {
 
 /// Act as dynamic linker, run `relocate`.
 #[test]
-#[cfg_attr(target_arch = "x86", ignore)] // FIXME make it work on x86
 fn example_crate_origin_start_dynamic_linker() {
     use assert_cmd::Command;
 


### PR DESCRIPTION
The trick of using a static variable initialized with an address to obtain the pre-relocated address no longer appears to work on Rust nightly, so replace it with code that reads the static start address out of the `e_start` field of the executable's ELF header. This is less "sneaky", so it should be more robust against compiler changes.

And, fix the 32-bit x86 relocation code and re-enable all the tests on x86.