### PR TITLE
Don't disable default features in rustix-futex-sync.

### DIFF
--- a/test-crates/origin-start/Cargo.toml
+++ b/test-crates/origin-start/Cargo.toml
@@ -10,7 +10,7 @@ atomic-dbg = { version = "0.1.8", default-features = false }
 rustix-dlmalloc = { version = "0.1.0", features = ["global"] }
 compiler_builtins = { version = "0.1.112", features = ["mem", "no-f16-f128"] }
 rustix = { version = "0.38", default-features = false, features = ["thread"] }
-rustix-futex-sync = { version = "0.2.1", default-features = false }
+rustix-futex-sync = "0.2.1"
 
 # This is just a test crate, and not part of the origin workspace.
 [workspace]


### PR DESCRIPTION
Rustix-futex-sync doesn't have any default features currently, so there's no need to disable them.