### PR TITLE
Couple of tls handling changes

### DIFF
--- a/src/thread/libc.rs
+++ b/src/thread/libc.rs
@@ -213,12 +213,12 @@ pub fn errno_location() -> *mut i32 {
     unsafe { __errno_location() }
 }
 
-/// Return the TLS address for the given `offset` for the current thread.
+/// Return the TLS address for the given `module` and `offset` for the current
+/// thread.
 #[inline]
 #[must_use]
-pub fn current_tls_addr(offset: usize) -> *mut c_void {
-    let p = [1, offset];
-    unsafe { __tls_get_addr(&p) }
+pub fn current_tls_addr(module: usize, offset: usize) -> *mut c_void {
+    unsafe { __tls_get_addr(&[module, offset]) }
 }
 
 /// Return the current thread's stack address (lowest address), size, and guard

--- a/src/thread/linux_raw.rs
+++ b/src/thread/linux_raw.rs
@@ -1005,10 +1005,15 @@ pub fn errno_location() -> *mut i32 {
     unsafe { core::ptr::addr_of_mut!((*current_metadata()).thread.errno_val).cast::<i32>() }
 }
 
-/// Return the TLS address for the given `offset` for the current thread.
+/// Return the TLS address for the given `module` and `offset` for the current
+/// thread.
 #[inline]
 #[must_use]
-pub fn current_tls_addr(offset: usize) -> *mut c_void {
+pub fn current_tls_addr(module: usize, offset: usize) -> *mut c_void {
+    // Offset 0 is the generation field, and we don't support dynamic linking,
+    // so we should only ever see 1 here.
+    assert_eq!(module, 1);
+
     // Platforms where TLS data goes after the ABI-exposed fields.
     #[cfg(any(target_arch = "aarch64", target_arch = "arm", target_arch = "riscv64"))]
     {


### PR DESCRIPTION
* Support passing the module id to current_tls_addr. When using libc this will be passe through to __tls_get_addr, while for the linux_raw impl it asserts that the module id is 1 until dynamic linking is implemented.
* Share most tls handling code between initialize_main and create as suggested in https://github.com/sunfishcode/origin/pull/111#pullrequestreview-1920265103.