### PR TITLE
Update to the latest Rust nightly.

### DIFF
--- a/example-crates/basic/src/main.rs
+++ b/example-crates/basic/src/main.rs
@@ -4,7 +4,7 @@ fn main() {
     eprintln!("Hello from main thread");
 
     program::at_exit(Box::new(|| {
-        eprintln!("Hello from an `program::at_exit` handler")
+        eprintln!("Hello from a `program::at_exit` handler")
     }));
     thread::at_exit(Box::new(|| {
         eprintln!("Hello from a main-thread `thread::at_exit` handler")

--- a/example-crates/external-start/src/main.rs
+++ b/example-crates/external-start/src/main.rs
@@ -59,7 +59,7 @@ unsafe fn origin_main(_argc: usize, _argv: *mut *mut u8, _envp: *mut *mut u8) ->
     eprintln!("Hello from main thread");
 
     program::at_exit(Box::new(|| {
-        eprintln!("Hello from an `program::at_exit` handler")
+        eprintln!("Hello from a `program::at_exit` handler")
     }));
     thread::at_exit(Box::new(|| {
         eprintln!("Hello from a main-thread `thread::at_exit` handler")

--- a/example-crates/no-std/src/main.rs
+++ b/example-crates/no-std/src/main.rs
@@ -29,7 +29,7 @@ fn start(_argc: isize, _argv: *const *const u8) -> isize {
     eprintln!("Hello from main thread");
 
     program::at_exit(Box::new(|| {
-        eprintln!("Hello from an `program::at_exit` handler")
+        eprintln!("Hello from a `program::at_exit` handler")
     }));
     thread::at_exit(Box::new(|| {
         eprintln!("Hello from a main-thread `thread::at_exit` handler")

--- a/example-crates/origin-start-dynamic-linker/src/lib.rs
+++ b/example-crates/origin-start-dynamic-linker/src/lib.rs
@@ -30,7 +30,7 @@ unsafe fn origin_main(_argc: usize, _argv: *mut *mut u8, _envp: *mut *mut u8) ->
     eprintln!("Hello from main thread");
 
     program::at_exit(Box::new(|| {
-        eprintln!("Hello from an `program::at_exit` handler")
+        eprintln!("Hello from a `program::at_exit` handler")
     }));
     thread::at_exit(Box::new(|| {
         eprintln!("Hello from a main-thread `thread::at_exit` handler")

--- a/example-crates/origin-start-lto/src/main.rs
+++ b/example-crates/origin-start-lto/src/main.rs
@@ -30,7 +30,7 @@ unsafe fn origin_main(_argc: usize, _argv: *mut *mut u8, _envp: *mut *mut u8) ->
     eprintln!("Hello from main thread");
 
     program::at_exit(Box::new(|| {
-        eprintln!("Hello from an `program::at_exit` handler")
+        eprintln!("Hello from a `program::at_exit` handler")
     }));
     thread::at_exit(Box::new(|| {
         eprintln!("Hello from a main-thread `thread::at_exit` handler")

--- a/example-crates/origin-start/src/main.rs
+++ b/example-crates/origin-start/src/main.rs
@@ -30,7 +30,7 @@ unsafe fn origin_main(_argc: usize, _argv: *mut *mut u8, _envp: *mut *mut u8) ->
     eprintln!("Hello from main thread");
 
     program::at_exit(Box::new(|| {
-        eprintln!("Hello from an `program::at_exit` handler")
+        eprintln!("Hello from a `program::at_exit` handler")
     }));
     thread::at_exit(Box::new(|| {
         eprintln!("Hello from a main-thread `thread::at_exit` handler")

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "nightly-2024-06-23"
+channel = "nightly-2024-08-19"
 components = ["rustc", "cargo", "rust-std", "rust-src", "rustfmt"]

--- a/src/arch/x86.rs
+++ b/src/arch/x86.rs
@@ -54,13 +54,13 @@ pub(super) fn dynamic_table_addr() -> *const Elf_Dyn {
         asm!(
             ".weak _DYNAMIC",
             ".hidden _DYNAMIC",
-            "call 0f",
+            "call 2f",
             ".cfi_adjust_cfa_offset 4",
-            "0:",
+            "2:",
             "pop {0}",
             ".cfi_adjust_cfa_offset -4",
-            "1:",
-            "add {0}, offset _GLOBAL_OFFSET_TABLE_+(1b-0b)",
+            "3:",
+            "add {0}, offset _GLOBAL_OFFSET_TABLE_+(3b-2b)",
             "lea {0}, [{0} + _DYNAMIC@GOTOFF]",
             out(reg) addr
         )
@@ -75,13 +75,13 @@ pub(super) fn ehdr_addr() -> *const Elf_Ehdr {
     let addr;
     unsafe {
         asm!(
-            "call 0f",
+            "call 2f",
             ".cfi_adjust_cfa_offset 4",
-            "0:",
+            "2:",
             "pop {0}",
             ".cfi_adjust_cfa_offset -4",
-            "1:",
-            "add {0}, offset _GLOBAL_OFFSET_TABLE_+(1b-0b)",
+            "3:",
+            "add {0}, offset _GLOBAL_OFFSET_TABLE_+(3b-2b)",
             "lea {0}, [{0} + __ehdr_start@GOTOFF]",
             out(reg) addr
         )
@@ -245,7 +245,7 @@ pub(super) unsafe fn clone(
         // in the child.
         "int 0x80",           // Do the `clone` system call.
         "test eax, eax",      // Branch if we're in the parent.
-        "jnz 0f",
+        "jnz 2f",
 
         // Child thread.
         "pop edi",            // Load `fn_` from the child stack.
@@ -259,7 +259,7 @@ pub(super) unsafe fn clone(
         "jmp {entry}",        // Call `entry`.
 
         // Parent thread.
-        "0:",
+        "2:",
         "pop ebp",            // Restore incoming register value.
         "pop esi",            // Restore incoming register value.
 

--- a/src/arch/x86.rs
+++ b/src/arch/x86.rs
@@ -60,7 +60,16 @@ pub(super) fn dynamic_table_addr() -> *const Elf_Dyn {
             "pop {0}",
             ".cfi_adjust_cfa_offset -4",
             "3:",
-            "add {0}, offset _GLOBAL_OFFSET_TABLE_+(3b-2b)",
+            // Use "2" and "3" instead of "0" and "1" because "0b" and "1b" are
+            // parsed as binary literals rather than as label references. And,
+            // use a `.set` here because the assembler doesn't seem to support
+            // the symbol difference expression in an instruction operand
+            // context. Then, using a `.set` requires a symbol name, and there
+            // appears to be no syntax or convention for temporary labels that
+            // can be used with `.set`, so we use a prefix of "usercode_" to
+            // hopefully avoid colliding with any compiler symbols.
+            ".set usercode_offset, _GLOBAL_OFFSET_TABLE_+(3b-2b)",
+            "add {0}, offset usercode_offset",
             "lea {0}, [{0} + _DYNAMIC@GOTOFF]",
             out(reg) addr
         )
@@ -81,7 +90,9 @@ pub(super) fn ehdr_addr() -> *const Elf_Ehdr {
             "pop {0}",
             ".cfi_adjust_cfa_offset -4",
             "3:",
-            "add {0}, offset _GLOBAL_OFFSET_TABLE_+(3b-2b)",
+            // See above for an explanation of `usercode_offset`.
+            ".set usercode_offset, _GLOBAL_OFFSET_TABLE_+(3b-2b)",
+            "add {0}, offset usercode_offset",
             "lea {0}, [{0} + __ehdr_start@GOTOFF]",
             out(reg) addr
         )

--- a/src/arch/x86_64.rs
+++ b/src/arch/x86_64.rs
@@ -188,7 +188,7 @@ pub(super) unsafe fn clone(
     asm!(
         "syscall",            // Do the `clone` system call.
         "test eax, eax",      // Branch if we're in the parent thread.
-        "jnz 0f",
+        "jnz 2f",
 
         // Child thread.
         "mov rdi, r9",        // Pass `fn_` as the first argument.
@@ -199,7 +199,7 @@ pub(super) unsafe fn clone(
         "jmp {entry}",        // Call `entry`.
 
         // Parent thread.
-        "0:",
+        "2:",
 
         entry = sym super::thread::entry,
         inlateout("rax") __NR_clone as usize => r0,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,7 +2,6 @@
 #![deny(missing_docs)]
 #![cfg_attr(debug_assertions, allow(internal_features))]
 #![cfg_attr(docsrs, feature(doc_cfg))]
-#![feature(asm_const)]
 #![feature(naked_functions)]
 #![cfg_attr(debug_assertions, feature(link_llvm_intrinsics))]
 #![cfg_attr(feature = "experimental-relocate", feature(cfg_relocation_model))]

--- a/test-crates/origin-start/src/bin/tls.rs
+++ b/test-crates/origin-start/src/bin/tls.rs
@@ -98,7 +98,7 @@ unsafe fn origin_main(_argc: usize, _argv: *mut *mut u8, _envp: *mut *mut u8) ->
 
 struct SyncTestData([*const u32; 3]);
 unsafe impl Sync for SyncTestData {}
-static TEST_DATA: SyncTestData = unsafe {
+static TEST_DATA: SyncTestData = {
     SyncTestData([
         without_provenance_mut(0xa0b1a2b3a4b5a6b7_u64 as usize),
         addr_of_mut!(SOME_REGULAR_DATA),

--- a/tests/example_crates.rs
+++ b/tests/example_crates.rs
@@ -161,7 +161,8 @@ fn example_crate_origin_start_dynamic_linker() {
         vec![]
     };
 
-    // Build a dummy executable with the previously built liborigin_start.so as dynamic linker.
+    // Build a dummy executable with the previously built liborigin_start.so as
+    // dynamic linker.
     let assert = Command::new("rustc")
         .args(&[
             "-",

--- a/tests/utils/mod.rs
+++ b/tests/utils/mod.rs
@@ -52,7 +52,7 @@ pub const COMMON_STDERR: &str = "Hello from main thread\n\
     Hello from child thread's `thread::at_exit` handler\n\
     Goodbye from main\n\
     Hello from a main-thread `thread::at_exit` handler\n\
-    Hello from an `program::at_exit` handler\n";
+    Hello from a `program::at_exit` handler\n";
 
 /// Stderr output for the origin-start-no-alloc crate.
 pub const NO_ALLOC_STDERR: &str = "Hello!\n";


### PR DESCRIPTION
On x86 and x86_64, this renames labels "0" and "1" to "2" and "3" to fix the clippy `binary_asm_labels` diagnostic.