### PR TITLE
Update to the latest nightly Rust.

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -58,7 +58,7 @@ jobs:
         rustup target add ${{ matrix.target }}
       if: matrix.target != ''
 
-    - uses: actions/cache@v3
+    - uses: actions/cache@v4
       with:
         path: ${{ runner.tool_cache }}/qemu
         key: qemu-${{ matrix.target }}-${{ env.QEMU_BUILD_VERSION }}-patched

--- a/example-crates/external-start/src/main.rs
+++ b/example-crates/external-start/src/main.rs
@@ -89,5 +89,6 @@ unsafe fn origin_main(_argc: usize, _argv: *mut *mut u8, _envp: *mut *mut u8) ->
 // linker, however origin gains control before libc can call this `main`.
 #[no_mangle]
 unsafe fn main(_argc: i32, _argv: *mut *mut u8, _envp: *mut *mut u8) -> i32 {
+    eprintln!("Main was not supposed to be called!");
     core::intrinsics::abort();
 }

--- a/example-crates/tiny/README.md
+++ b/example-crates/tiny/README.md
@@ -10,7 +10,7 @@ and `.comment` sections:
 objcopy -R .eh_frame -R .comment target/release/tiny even-smaller
 ```
 
-On x86-64, this produces a executable with size 408 bytes.
+On x86-64, this produces an executable with size 408 bytes.
 
 How is this achieved?
 
@@ -29,7 +29,7 @@ needed for our minimal test program:
 origin = { path = "../..", default-features = false, features = ["origin-start"] }
 ```
 
-Then, we add a `#[profile.release]` section to our Cargo.toml, to enable
+Then, we add a `[profile.release]` section to our Cargo.toml, to enable
 several optimizations:
 
 ```toml

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "nightly-2024-08-19"
+channel = "nightly-2024-10-06"
 components = ["rustc", "cargo", "rust-std", "rust-src", "rustfmt"]

--- a/test-crates/origin-start/src/bin/canary.rs
+++ b/test-crates/origin-start/src/bin/canary.rs
@@ -11,6 +11,7 @@ extern crate alloc;
 extern crate compiler_builtins;
 
 use atomic_dbg::dbg;
+use core::cell::UnsafeCell;
 use core::arch::asm;
 use origin::{program, thread};
 
@@ -27,7 +28,7 @@ extern "C" fn eh_personality() {}
 static GLOBAL_ALLOCATOR: rustix_dlmalloc::GlobalDlmalloc = rustix_dlmalloc::GlobalDlmalloc;
 
 extern "C" {
-    static mut __stack_chk_guard: usize;
+    static __stack_chk_guard: UnsafeCell<usize>;
 }
 
 /// Read the canary field from its well-known location in TLS, if there is one,
@@ -55,13 +56,13 @@ fn tls_guard() -> usize {
 
 #[no_mangle]
 unsafe fn origin_main(_argc: usize, _argv: *mut *mut u8, _envp: *mut *mut u8) -> i32 {
-    assert_ne!(__stack_chk_guard, 0);
-    assert_eq!(__stack_chk_guard, tls_guard());
+    assert_ne!(*__stack_chk_guard.get(), 0);
+    assert_eq!(*__stack_chk_guard.get(), tls_guard());
 
     let thread = thread::create(
         |_args| {
-            assert_ne!(__stack_chk_guard, 0);
-            assert_eq!(__stack_chk_guard, tls_guard());
+            assert_ne!(*__stack_chk_guard.get(), 0);
+            assert_eq!(*__stack_chk_guard.get(), tls_guard());
             None
         },
         &[],
@@ -72,8 +73,8 @@ unsafe fn origin_main(_argc: usize, _argv: *mut *mut u8, _envp: *mut *mut u8) ->
 
     thread::join(thread);
 
-    assert_ne!(__stack_chk_guard, 0);
-    assert_eq!(__stack_chk_guard, tls_guard());
+    assert_ne!(*__stack_chk_guard.get(), 0);
+    assert_eq!(*__stack_chk_guard.get(), tls_guard());
 
     program::exit(203);
 }

--- a/test-crates/origin-start/src/bin/canary.rs
+++ b/test-crates/origin-start/src/bin/canary.rs
@@ -48,7 +48,7 @@ fn tls_guard() -> usize {
 
     #[cfg(not(any(target_arch = "x86", target_arch = "x86_64")))]
     unsafe {
-        ret = __stack_chk_guard;
+        ret = *__stack_chk_guard.get();
     }
 
     ret


### PR DESCRIPTION
Update to nightly-2024-10-06, fix new warnings about static mut references, and a few other minor cleanups.