### PR TITLE
Add `nostack` to the abort function asm sequences.

### DIFF
--- a/src/arch/aarch64.rs
+++ b/src/arch/aarch64.rs
@@ -47,7 +47,7 @@ pub(super) unsafe extern "C" fn _start() -> ! {
 #[cfg(relocation_model = "pic")]
 pub(super) fn abort() -> ! {
     unsafe {
-        asm!("brk #0x1", options(noreturn));
+        asm!("brk #0x1", options(noreturn, nostack));
     }
 }
 

--- a/src/arch/arm.rs
+++ b/src/arch/arm.rs
@@ -47,7 +47,7 @@ pub(super) unsafe extern "C" fn _start() -> ! {
 #[cfg(relocation_model = "pic")]
 pub(super) fn abort() -> ! {
     unsafe {
-        asm!(".inst 0xe7ffdefe", options(noreturn));
+        asm!(".inst 0xe7ffdefe", options(noreturn, nostack));
     }
 }
 

--- a/src/arch/riscv64.rs
+++ b/src/arch/riscv64.rs
@@ -47,7 +47,7 @@ pub(super) unsafe extern "C" fn _start() -> ! {
 #[cfg(relocation_model = "pic")]
 pub(super) fn abort() -> ! {
     unsafe {
-        asm!("unimp", options(noreturn));
+        asm!("unimp", options(noreturn, nostack));
     }
 }
 

--- a/src/arch/x86.rs
+++ b/src/arch/x86.rs
@@ -52,7 +52,7 @@ pub(super) unsafe extern "C" fn _start() -> ! {
 #[cfg(relocation_model = "pic")]
 pub(super) fn abort() -> ! {
     unsafe {
-        asm!("ud2", options(noreturn));
+        asm!("ud2", options(noreturn, nostack));
     }
 }
 

--- a/src/arch/x86_64.rs
+++ b/src/arch/x86_64.rs
@@ -47,7 +47,7 @@ pub(super) unsafe extern "C" fn _start() -> ! {
 #[cfg(relocation_model = "pic")]
 pub(super) fn abort() -> ! {
     unsafe {
-        asm!("ud2", options(noreturn));
+        asm!("ud2", options(noreturn, nostack));
     }
 }
 


### PR DESCRIPTION
CPU abort instructions do not use stack, so we can use `nostack`.