### PR TITLE
Put `program::at_exit` and `thread::at_exit` behind feature flags.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -58,7 +58,7 @@ features = ["param"]
 assert_cmd = "2.0.12"
 
 [features]
-default = ["std", "log", "libc", "errno", "thread", "init-fini-arrays"]
+default = ["std", "log", "libc", "errno", "thread", "init-fini-arrays", "program-at-exit", "thread-at-exit"]
 std = ["rustix/std", "bitflags/std", "alloc"]
 rustc-dep-of-std = [
     "dep:core",
@@ -89,8 +89,8 @@ external-start = ["take-charge"]
 # The loggers depend on a `.init_array` entry to initialize themselves, and
 # `env_logger` needs it so that `c-scape` can initialize environment variables
 # and make `RUST_LOG` available.
-atomic-dbg-logger = ["atomic-dbg/log", "init-fini-arrays"]
-env_logger = ["dep:env_logger", "init-fini-arrays"]
+atomic-dbg-logger = ["atomic-dbg/log", "init-array"]
+env_logger = ["dep:env_logger", "init-array"]
 
 # Disable logging.
 max_level_off = ["log/max_level_off"]
@@ -105,7 +105,7 @@ thread = ["rustix/thread", "rustix/mm", "param", "rustix/process", "rustix/runti
 # Enable support for signal handlers.
 signal = ["rustix/runtime"]
 
-# Enable support for `rustix::param`.
+# Have origin call `rustix::param::init`.
 param = ["rustix/param"]
 
 # Enable support for ELF `.init_array` and `.fini_array`.
@@ -116,6 +116,12 @@ init-array = []
 
 # Enable support for ELF `.fini_array`.
 fini-array = []
+
+# Enable support for `origin::program::at_exit`.
+program-at-exit = ["alloc"]
+
+# Enable support for `origin::thread::at_exit`.
+thread-at-exit = ["alloc", "thread"]
 
 # Enable highly experimental support for performing startup-time relocations,
 # needed to support statically-linked PIE executables.
@@ -171,4 +177,4 @@ panic-handler-abort = ["unwinding?/panic-handler-dummy"]
 getauxval = ["rustix/param"]
 
 [package.metadata.docs.rs]
-features = ["take-charge", "origin-start", "thread", "signal", "nightly"]
+features = ["origin-start", "thread", "signal", "program-at-exit", "thread-at-exit", "nightly"]

--- a/example-crates/external-start/Cargo.toml
+++ b/example-crates/external-start/Cargo.toml
@@ -7,7 +7,7 @@ publish = false
 [dependencies]
 # Origin can be depended on just like any other crate. For no_std, disable
 # the default features, and the desired features.
-origin = { path = "../..", default-features = false, features = ["take-charge", "external-start", "thread", "alloc", "eh-personality-continue", "panic-handler-abort", "nightly"] }
+origin = { path = "../..", default-features = false, features = ["take-charge", "external-start", "thread", "alloc", "program-at-exit", "thread-at-exit", "eh-personality-continue", "panic-handler-abort", "nightly"] }
 
 # Ensure that libc gets linked.
 libc = { version = "0.2", default-features = false }

--- a/example-crates/no-std/Cargo.toml
+++ b/example-crates/no-std/Cargo.toml
@@ -7,7 +7,7 @@ publish = false
 [dependencies]
 # Origin can be depended on just like any other crate. For no_std, disable
 # the default features. And enable "libc" to enable the libc implementations.
-origin = { path = "../..", default-features = false, features = ["libc", "thread", "alloc", "eh-personality-continue", "panic-handler-abort", "nightly"] }
+origin = { path = "../..", default-features = false, features = ["libc", "thread", "alloc", "program-at-exit", "thread-at-exit", "eh-personality-continue", "panic-handler-abort", "nightly"] }
 
 # Crates to help writing no_std code.
 atomic-dbg = { version = "0.1.8", default-features = false }

--- a/example-crates/origin-start-dynamic-linker/Cargo.toml
+++ b/example-crates/origin-start-dynamic-linker/Cargo.toml
@@ -10,7 +10,7 @@ crate-type = ["cdylib"]
 [dependencies]
 # Origin can be depended on just like any other crate. For no_std, disable
 # the default features, and the desired features.
-origin = { path = "../..", default-features = false, features = ["take-charge", "origin-start", "thread", "alloc", "experimental-relocate", "eh-personality-continue", "panic-handler-abort", "nightly"] }
+origin = { path = "../..", default-features = false, features = ["origin-start", "thread", "alloc", "program-at-exit", "thread-at-exit", "experimental-relocate", "eh-personality-continue", "panic-handler-abort", "nightly"] }
 
 # Crates to help writing no_std code.
 atomic-dbg = { version = "0.1.8", default-features = false }

--- a/example-crates/origin-start-lto/Cargo.toml
+++ b/example-crates/origin-start-lto/Cargo.toml
@@ -7,7 +7,7 @@ publish = false
 [dependencies]
 # Origin can be depended on just like any other crate. For no_std, disable
 # the default features, and the desired features.
-origin = { path = "../..", default-features = false, features = ["take-charge", "origin-start", "thread", "alloc", "eh-personality-continue", "panic-handler-abort", "nightly"] }
+origin = { path = "../..", default-features = false, features = ["origin-start", "thread", "alloc", "program-at-exit", "thread-at-exit", "eh-personality-continue", "panic-handler-abort", "nightly"] }
 
 # Crates to help writing no_std code.
 atomic-dbg = { version = "0.1.8", default-features = false }

--- a/example-crates/origin-start-stable/Cargo.toml
+++ b/example-crates/origin-start-stable/Cargo.toml
@@ -7,7 +7,7 @@ publish = false
 [dependencies]
 # Origin can be depended on just like any other crate. For no_std, disable
 # the default features, and the desired features.
-origin = { path = "../..", default-features = false, features = ["take-charge", "origin-start", "thread", "alloc", "eh-personality-continue", "panic-handler-abort"] }
+origin = { path = "../..", default-features = false, features = ["origin-start", "thread", "alloc", "program-at-exit", "thread-at-exit", "eh-personality-continue", "panic-handler-abort"] }
 
 # Crates to help writing no_std code.
 atomic-dbg = { version = "0.1.8", default-features = false }

--- a/example-crates/origin-start/Cargo.toml
+++ b/example-crates/origin-start/Cargo.toml
@@ -7,7 +7,7 @@ publish = false
 [dependencies]
 # Origin can be depended on just like any other crate. For no_std, disable
 # the default features, and the desired features.
-origin = { path = "../..", default-features = false, features = ["take-charge", "origin-start", "thread", "alloc", "eh-personality-continue", "panic-handler-abort", "nightly"] }
+origin = { path = "../..", default-features = false, features = ["origin-start", "thread", "alloc", "program-at-exit", "thread-at-exit", "eh-personality-continue", "panic-handler-abort", "nightly"] }
 
 # Crates to help writing no_std code.
 atomic-dbg = { version = "0.1.8", default-features = false }

--- a/src/program/libc.rs
+++ b/src/program/libc.rs
@@ -28,14 +28,15 @@
 //! with origin's goal of providing Rust-idiomatic interfaces, however it does
 //! mean that origin can avoid doing any work that users might not need.
 
-#[cfg(feature = "alloc")]
+#[cfg(feature = "program-at-exit")]
 use alloc::boxed::Box;
+#[cfg(feature = "program-at-exit")]
 use core::ptr::null_mut;
 use linux_raw_sys::ctypes::c_int;
 
 /// Register a function to be called when [`exit`] is called.
-#[cfg(feature = "alloc")]
-#[cfg_attr(docsrs, doc(cfg(feature = "alloc")))]
+#[cfg(feature = "program-at-exit")]
+#[cfg_attr(docsrs, doc(cfg(feature = "program-at-exit")))]
 pub fn at_exit(func: Box<dyn FnOnce() + Send>) {
     use core::ffi::c_void;
 

--- a/src/thread/libc.rs
+++ b/src/thread/libc.rs
@@ -2,6 +2,7 @@
 
 #[cfg(not(feature = "nightly"))]
 use crate::ptr::{with_exposed_provenance_mut, without_provenance_mut, Polyfill as _};
+#[cfg(feature = "thread-at-exit")]
 use alloc::boxed::Box;
 use core::ffi::{c_int, c_void};
 use core::mem::{size_of, transmute, zeroed};
@@ -23,6 +24,7 @@ extern "C" {
     fn __errno_location() -> *mut c_int;
     fn __tls_get_addr(p: &[usize; 2]) -> *mut c_void;
 
+    #[cfg(feature = "thread-at-exit")]
     static __dso_handle: *const c_void;
 }
 
@@ -154,6 +156,7 @@ pub unsafe fn create(
 }
 
 /// Registers a function to call when the current thread exits.
+#[cfg(feature = "thread-at-exit")]
 pub fn at_exit(func: Box<dyn FnOnce()>) {
     extern "C" fn call(arg: *mut c_void) {
         unsafe {
@@ -322,6 +325,7 @@ pub fn yield_current() {
 }
 
 /// Return the address of `__dso_handle`, appropriately casted.
+#[cfg(feature = "thread-at-exit")]
 unsafe fn dso_handle() -> *mut c_void {
     let dso_handle: *const *const c_void = &__dso_handle;
     dso_handle.cast::<c_void>().cast_mut()

--- a/test-crates/origin-start/Cargo.toml
+++ b/test-crates/origin-start/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 publish = false
 
 [dependencies]
-origin = { path = "../..", default-features = false, features = ["take-charge", "origin-start", "thread", "alloc", "eh-personality-continue", "panic-handler-abort", "nightly"] }
+origin = { path = "../..", default-features = false, features = ["origin-start", "thread", "alloc", "program-at-exit", "thread-at-exit", "eh-personality-continue", "panic-handler-abort", "nightly"] }
 atomic-dbg = { version = "0.1.8", default-features = false }
 rustix-dlmalloc = { version = "0.1.0", features = ["global"] }
 rustix = { version = "0.38", default-features = false, features = ["thread"] }


### PR DESCRIPTION
This allow them to be excluded when not needed, reducing code size.