### PR TITLE
Unlock `DTORS` before calling the dtor functions.

### DIFF
--- a/test-crates/origin-start/src/bin/main-thread-dtors-adding-dtors.rs
+++ b/test-crates/origin-start/src/bin/main-thread-dtors-adding-dtors.rs
@@ -1,0 +1,36 @@
+//! Test main thread dtors that add new dtors.
+
+#![no_std]
+#![no_main]
+
+extern crate alloc;
+
+use alloc::boxed::Box;
+use core::sync::atomic::{AtomicBool, Ordering};
+use origin::thread;
+
+#[global_allocator]
+static GLOBAL_ALLOCATOR: rustix_dlmalloc::GlobalDlmalloc = rustix_dlmalloc::GlobalDlmalloc;
+
+static FLAG: AtomicBool = AtomicBool::new(false);
+
+#[no_mangle]
+unsafe fn origin_main(_argc: usize, _argv: *mut *mut u8, _envp: *mut *mut u8) -> i32 {
+    thread::at_exit(Box::new(|| {
+        assert!(FLAG.load(Ordering::Relaxed));
+    }));
+
+    thread::at_exit(Box::new(|| {
+        thread::at_exit(Box::new(|| {
+            thread::at_exit(Box::new(|| {
+                FLAG.store(true, Ordering::Relaxed);
+            }));
+        }));
+    }));
+
+    thread::at_exit(Box::new(|| {
+        assert!(!FLAG.load(Ordering::Relaxed));
+    }));
+
+    0
+}

--- a/test-crates/origin-start/src/bin/program-dtors-adding-dtors.rs
+++ b/test-crates/origin-start/src/bin/program-dtors-adding-dtors.rs
@@ -1,0 +1,36 @@
+//! Test program dtors that add new dtors.
+
+#![no_std]
+#![no_main]
+
+extern crate alloc;
+
+use alloc::boxed::Box;
+use core::sync::atomic::{AtomicBool, Ordering};
+use origin::program;
+
+#[global_allocator]
+static GLOBAL_ALLOCATOR: rustix_dlmalloc::GlobalDlmalloc = rustix_dlmalloc::GlobalDlmalloc;
+
+static FLAG: AtomicBool = AtomicBool::new(false);
+
+#[no_mangle]
+unsafe fn origin_main(_argc: usize, _argv: *mut *mut u8, _envp: *mut *mut u8) -> i32 {
+    program::at_exit(Box::new(|| {
+        assert!(FLAG.load(Ordering::Relaxed));
+    }));
+
+    program::at_exit(Box::new(|| {
+        program::at_exit(Box::new(|| {
+            program::at_exit(Box::new(|| {
+                FLAG.store(true, Ordering::Relaxed);
+            }))
+        }))
+    }));
+
+    program::at_exit(Box::new(|| {
+        assert!(!FLAG.load(Ordering::Relaxed));
+    }));
+
+    0
+}

--- a/test-crates/origin-start/src/bin/thread-dtors-adding-dtors.rs
+++ b/test-crates/origin-start/src/bin/thread-dtors-adding-dtors.rs
@@ -1,0 +1,48 @@
+//! Test thread dtors that add new dtors.
+
+#![no_std]
+#![no_main]
+
+extern crate alloc;
+
+use alloc::boxed::Box;
+use core::sync::atomic::{AtomicBool, Ordering};
+use origin::thread;
+
+#[global_allocator]
+static GLOBAL_ALLOCATOR: rustix_dlmalloc::GlobalDlmalloc = rustix_dlmalloc::GlobalDlmalloc;
+
+static FLAG: AtomicBool = AtomicBool::new(false);
+
+#[no_mangle]
+unsafe fn origin_main(_argc: usize, _argv: *mut *mut u8, _envp: *mut *mut u8) -> i32 {
+    let thread = thread::create(
+        |_args| {
+            thread::at_exit(Box::new(|| {
+                assert!(FLAG.load(Ordering::Relaxed));
+            }));
+
+            thread::at_exit(Box::new(|| {
+                thread::at_exit(Box::new(|| {
+                    thread::at_exit(Box::new(|| {
+                        FLAG.store(true, Ordering::Relaxed);
+                    }));
+                }));
+            }));
+
+            thread::at_exit(Box::new(|| {
+                assert!(!FLAG.load(Ordering::Relaxed));
+            }));
+
+            None
+        },
+        &[],
+        thread::default_stack_size(),
+        thread::default_guard_size(),
+    )
+    .unwrap();
+
+    thread::join(thread);
+
+    0
+}

--- a/tests/test_crates.rs
+++ b/tests/test_crates.rs
@@ -87,3 +87,39 @@ fn test_detach() {
 fn test_canary() {
     test_crate("origin-start", &["--bin=canary"], &[], "", "", Some(203));
 }
+
+#[test]
+fn test_program_dtors_adding_dtors() {
+    test_crate(
+        "origin-start",
+        &["--bin=program-dtors-adding-dtors"],
+        &[],
+        "",
+        "",
+        Some(0),
+    );
+}
+
+#[test]
+fn test_thread_dtors_adding_dtors() {
+    test_crate(
+        "origin-start",
+        &["--bin=thread-dtors-adding-dtors"],
+        &[],
+        "",
+        "",
+        Some(0),
+    );
+}
+
+#[test]
+fn test_main_thread_dtors_adding_dtors() {
+    test_crate(
+        "origin-start",
+        &["--bin=main-thread-dtors-adding-dtors"],
+        &[],
+        "",
+        "",
+        Some(0),
+    );
+}


### PR DESCRIPTION
This allows dtor functions to add more dtor functions.

And, don't unlock `DTORS` when we're done with it, so that nothing else tries to access it.