### PR TITLE
Replace `abort()` with `trap()`.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,8 @@
 
 ## Changes
 
-`program::abort` has been renamed to `progaram::trap`.
+`program::abort` has been renamed to `progaram::trap`, and the
+"panic-handler-abort" feature has been renamed to "panic-handler-trap".
 
 # origin 0.22
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Changes
 
-`program::abort` has been renamed to `progaram::trap`, and the
+`program::abort` has been renamed to `program::trap`, and the
 "panic-handler-abort" feature has been renamed to "panic-handler-trap".
 
 # origin 0.22

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# origin 0.23
+
+## Changes
+
+`program::abort` has been renamed to `progaram::trap`.
+
 # origin 0.22
 
 ## Changes

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -156,7 +156,7 @@ eh-personality-continue = ["unwinding?/personality-dummy"]
 # Provide a `#[panic_handler]` function suitable for unwinding (for no-std).
 #
 # If you know your program never panics and want smaller code size, use
-# "panic-handler-abort" instead.
+# "panic-handler-trap" instead.
 #
 # This is only needed in no-std builds, as std provides a panic handler. See
 # [the "panic-handler" feature of the unwinding crate] for more details.
@@ -164,9 +164,9 @@ eh-personality-continue = ["unwinding?/personality-dummy"]
 # [the "panic-handler" feature of the unwinding crate]: https://crates.io/crates/unwinding#personality-and-other-utilities
 panic-handler = ["unwinding?/panic-handler"]
 
-# Provide a `#[panic_handler]` function that just aborts (for no-std). Use this
+# Provide a `#[panic_handler]` function that just traps (for no-std). Use this
 # if you know your program will never panic and don't want any extra code.
-panic-handler-abort = ["unwinding?/panic-handler-dummy"]
+panic-handler-trap = ["unwinding?/panic-handler-dummy"]
 
 # Enable this to define a C ABI-compatible `getauxval` function. Most Rust code
 # should use functions in [`rustix::param`] instead.

--- a/example-crates/external-start/Cargo.toml
+++ b/example-crates/external-start/Cargo.toml
@@ -7,7 +7,7 @@ publish = false
 [dependencies]
 # Origin can be depended on just like any other crate. For no_std, disable
 # the default features, and the desired features.
-origin = { path = "../..", default-features = false, features = ["external-start", "program-at-exit", "thread-at-exit", "eh-personality-continue", "panic-handler-abort", "nightly"] }
+origin = { path = "../..", default-features = false, features = ["external-start", "program-at-exit", "thread-at-exit", "eh-personality-continue", "panic-handler-trap", "nightly"] }
 
 # Ensure that libc gets linked.
 libc = { version = "0.2", default-features = false }

--- a/example-crates/external-start/src/main.rs
+++ b/example-crates/external-start/src/main.rs
@@ -77,5 +77,5 @@ unsafe fn origin_main(_argc: usize, _argv: *mut *mut u8, _envp: *mut *mut u8) ->
 #[no_mangle]
 unsafe fn main(_argc: i32, _argv: *mut *mut u8, _envp: *mut *mut u8) -> i32 {
     eprintln!("Main was not supposed to be called!");
-    program::abort();
+    program::trap();
 }

--- a/example-crates/no-std/Cargo.toml
+++ b/example-crates/no-std/Cargo.toml
@@ -7,7 +7,7 @@ publish = false
 [dependencies]
 # Origin can be depended on just like any other crate. For no_std, disable
 # the default features. And enable "libc" to enable the libc implementations.
-origin = { path = "../..", default-features = false, features = ["libc", "program-at-exit", "thread-at-exit", "eh-personality-continue", "panic-handler-abort", "nightly"] }
+origin = { path = "../..", default-features = false, features = ["libc", "program-at-exit", "thread-at-exit", "eh-personality-continue", "panic-handler-trap", "nightly"] }
 
 # Crates to help writing no_std code.
 atomic-dbg = { version = "0.1.8", default-features = false }

--- a/example-crates/origin-start-dynamic-linker/Cargo.toml
+++ b/example-crates/origin-start-dynamic-linker/Cargo.toml
@@ -10,7 +10,7 @@ crate-type = ["cdylib"]
 [dependencies]
 # Origin can be depended on just like any other crate. For no_std, disable
 # the default features, and the desired features.
-origin = { path = "../..", default-features = false, features = ["origin-start", "program-at-exit", "thread-at-exit", "experimental-relocate", "eh-personality-continue", "panic-handler-abort", "nightly"] }
+origin = { path = "../..", default-features = false, features = ["origin-start", "program-at-exit", "thread-at-exit", "experimental-relocate", "eh-personality-continue", "panic-handler-trap", "nightly"] }
 
 # Crates to help writing no_std code.
 atomic-dbg = { version = "0.1.8", default-features = false }

--- a/example-crates/origin-start-lto/Cargo.toml
+++ b/example-crates/origin-start-lto/Cargo.toml
@@ -7,7 +7,7 @@ publish = false
 [dependencies]
 # Origin can be depended on just like any other crate. For no_std, disable
 # the default features, and the desired features.
-origin = { path = "../..", default-features = false, features = ["origin-start", "program-at-exit", "thread-at-exit", "eh-personality-continue", "panic-handler-abort", "nightly"] }
+origin = { path = "../..", default-features = false, features = ["origin-start", "program-at-exit", "thread-at-exit", "eh-personality-continue", "panic-handler-trap", "nightly"] }
 
 # Crates to help writing no_std code.
 atomic-dbg = { version = "0.1.8", default-features = false }

--- a/example-crates/origin-start-no-alloc/Cargo.toml
+++ b/example-crates/origin-start-no-alloc/Cargo.toml
@@ -7,7 +7,7 @@ publish = false
 [dependencies]
 # Origin can be depended on just like any other crate. For no_std, disable
 # the default features, and the desired features.
-origin = { path = "../..", default-features = false, features = ["origin-start", "eh-personality-continue", "panic-handler-abort", "nightly"] }
+origin = { path = "../..", default-features = false, features = ["origin-start", "eh-personality-continue", "panic-handler-trap", "nightly"] }
 
 # Crates to help writing no_std code.
 atomic-dbg = { version = "0.1.8", default-features = false }

--- a/example-crates/origin-start-stable/Cargo.toml
+++ b/example-crates/origin-start-stable/Cargo.toml
@@ -7,7 +7,7 @@ publish = false
 [dependencies]
 # Origin can be depended on just like any other crate. For no_std, disable
 # the default features, and the desired features.
-origin = { path = "../..", default-features = false, features = ["origin-start", "program-at-exit", "thread-at-exit", "eh-personality-continue", "panic-handler-abort"] }
+origin = { path = "../..", default-features = false, features = ["origin-start", "program-at-exit", "thread-at-exit", "eh-personality-continue", "panic-handler-trap"] }
 
 # Crates to help writing no_std code.
 atomic-dbg = { version = "0.1.8", default-features = false }

--- a/example-crates/origin-start/Cargo.toml
+++ b/example-crates/origin-start/Cargo.toml
@@ -7,7 +7,7 @@ publish = false
 [dependencies]
 # Origin can be depended on just like any other crate. For no_std, disable
 # the default features, and the desired features.
-origin = { path = "../..", default-features = false, features = ["origin-start", "program-at-exit", "thread-at-exit", "eh-personality-continue", "panic-handler-abort", "nightly"] }
+origin = { path = "../..", default-features = false, features = ["origin-start", "program-at-exit", "thread-at-exit", "eh-personality-continue", "panic-handler-trap", "nightly"] }
 
 # Crates to help writing no_std code.
 atomic-dbg = { version = "0.1.8", default-features = false }

--- a/example-crates/tiny-hello/Cargo.toml
+++ b/example-crates/tiny-hello/Cargo.toml
@@ -8,7 +8,7 @@ publish = false
 # Origin can be depended on just like any other crate. For no_std, disable
 # the default features, and add the desired features.
 rustix = { version = "0.38.35", default-features = false, features = ["stdio"] }
-origin = { path = "../..", default-features = false, features = ["origin-start", "eh-personality-continue", "panic-handler-abort", "nightly", "optimize_for_size"] }
+origin = { path = "../..", default-features = false, features = ["origin-start", "eh-personality-continue", "panic-handler-trap", "nightly", "optimize_for_size"] }
 
 # This is just an example crate, and not part of the origin workspace.
 [workspace]

--- a/example-crates/tiny-hello/src/main.rs
+++ b/example-crates/tiny-hello/src/main.rs
@@ -13,7 +13,7 @@ unsafe fn origin_main(_argc: usize, _argv: *mut *mut u8, _envp: *mut *mut u8) ->
         match rustix::io::write(rustix::stdio::stdout(), message) {
             Ok(n) => remaining = &remaining[n as usize..],
             Err(rustix::io::Errno::INTR) => continue,
-            Err(_) => origin::program::abort(),
+            Err(_) => origin::program::trap(),
         }
     }
     origin::program::exit_immediately(0);

--- a/example-crates/tiny/Cargo.toml
+++ b/example-crates/tiny/Cargo.toml
@@ -7,7 +7,7 @@ publish = false
 [dependencies]
 # Origin can be depended on just like any other crate. For no_std, disable
 # the default features, and add the desired features.
-origin = { path = "../..", default-features = false, features = ["origin-start", "eh-personality-continue", "panic-handler-abort", "nightly", "optimize_for_size"] }
+origin = { path = "../..", default-features = false, features = ["origin-start", "eh-personality-continue", "panic-handler-trap", "nightly", "optimize_for_size"] }
 
 # This is just an example crate, and not part of the origin workspace.
 [workspace]

--- a/src/arch/aarch64.rs
+++ b/src/arch/aarch64.rs
@@ -41,10 +41,10 @@ naked_fn!(
     options(noreturn)
 );
 
-/// Abort the process without involving any panic handling code.
+/// Execute a trap instruction.
 ///
-/// This is a stable equivalent to `core::intrinsics::abort()`.
-pub(super) fn abort() -> ! {
+/// This is roughly equivalent to `core::intrinsics::abort()`.
+pub(super) fn trap() -> ! {
     unsafe {
         asm!("brk #0x1", options(noreturn, nostack));
     }
@@ -174,7 +174,7 @@ pub(super) unsafe fn relocation_mprotect_readonly(ptr: usize, len: usize) {
     if r0 != 0 {
         // Do not panic here as libstd's panic handler needs TLS, which is not
         // yet initialized at this point.
-        abort();
+        trap();
     }
 }
 

--- a/src/arch/arm.rs
+++ b/src/arch/arm.rs
@@ -41,10 +41,10 @@ naked_fn!(
     options(noreturn)
 );
 
-/// Abort the process without involving any panic handling code.
+/// Execute a trap instruction.
 ///
-/// This is a stable equivalent to `core::intrinsics::abort()`.
-pub(super) fn abort() -> ! {
+/// This is roughly equivalent to `core::intrinsics::abort()`.
+pub(super) fn trap() -> ! {
     unsafe {
         asm!(".inst 0xe7ffdefe", options(noreturn, nostack));
     }
@@ -186,7 +186,7 @@ pub(super) unsafe fn relocation_mprotect_readonly(ptr: usize, len: usize) {
     if r0 != 0 {
         // Do not panic here as libstd's panic handler needs TLS, which is not
         // yet initialized at this point.
-        abort();
+        trap();
     }
 }
 

--- a/src/arch/riscv64.rs
+++ b/src/arch/riscv64.rs
@@ -40,10 +40,10 @@ naked_fn!(
     options(noreturn)
 );
 
-/// Abort the process without involving any panic handling code.
+/// Execute a trap instruction.
 ///
-/// This is a stable equivalent to `core::intrinsics::abort()`.
-pub(super) fn abort() -> ! {
+/// This is roughly equivalent to `core::intrinsics::abort()`.
+pub(super) fn trap() -> ! {
     unsafe {
         asm!("unimp", options(noreturn, nostack));
     }
@@ -193,7 +193,7 @@ pub(super) unsafe fn relocation_mprotect_readonly(ptr: usize, len: usize) {
     if r0 != 0 {
         // Do not panic here as libstd's panic handler needs TLS, which is not
         // yet initialized at this point.
-        abort();
+        trap();
     }
 }
 

--- a/src/arch/x86.rs
+++ b/src/arch/x86.rs
@@ -51,10 +51,10 @@ naked_fn!(
     options(noreturn)
 );
 
-/// Abort the process without involving any panic handling code.
+/// Execute a trap instruction.
 ///
-/// This is a stable equivalent to `core::intrinsics::abort()`.
-pub(super) fn abort() -> ! {
+/// This is roughly equivalent to `core::intrinsics::abort()`.
+pub(super) fn trap() -> ! {
     unsafe {
         asm!("ud2", options(noreturn, nostack));
     }
@@ -208,7 +208,7 @@ pub(super) unsafe fn relocation_mprotect_readonly(ptr: usize, len: usize) {
     if r0 != 0 {
         // Do not panic here as libstd's panic handler needs TLS, which is not
         // yet initialized at this point.
-        abort();
+        trap();
     }
 }
 

--- a/src/arch/x86_64.rs
+++ b/src/arch/x86_64.rs
@@ -42,10 +42,10 @@ naked_fn!(
     options(noreturn)
 );
 
-/// Abort the process without involving any panic handling code.
+/// Execute a trap instruction.
 ///
-/// This is a stable equivalent to `core::intrinsics::abort()`.
-pub(super) fn abort() -> ! {
+/// This is roughly equivalent to `core::intrinsics::abort()`.
+pub(super) fn trap() -> ! {
     unsafe {
         asm!("ud2", options(noreturn, nostack));
     }
@@ -176,7 +176,7 @@ pub(super) unsafe fn relocation_mprotect_readonly(ptr: usize, len: usize) {
     if r0 != 0 {
         // Do not panic here as libstd's panic handler needs TLS, which is not
         // yet initialized at this point.
-        abort();
+        trap();
     }
 }
 

--- a/src/program/libc.rs
+++ b/src/program/libc.rs
@@ -78,9 +78,17 @@ pub fn exit_immediately(status: c_int) -> ! {
     }
 }
 
-/// Immediately abort the program due to the detection of an unrecoverable bug.
+/// Execute a trap instruction.
+///
+/// This will produce a `Signal::Ill`, which by default will immediately
+/// terminate the process.
 #[inline]
 #[cold]
-pub fn abort() -> ! {
-    unsafe { libc::abort() }
+pub fn trap() -> ! {
+    // Emulate the effect of executing a trap instruction.
+    loop {
+        unsafe {
+            libc::raise(libc::SIGILL);
+        }
+    }
 }

--- a/src/program/linux_raw.rs
+++ b/src/program/linux_raw.rs
@@ -340,9 +340,12 @@ pub fn exit_immediately(status: c_int) -> ! {
     rustix::runtime::exit_group(status)
 }
 
-/// Immediately abort the program due to the detection of an unrecoverable bug.
+/// Execute a trap instruction.
+///
+/// This will produce a `Signal::Ill`, which by default will immediately
+/// terminate the process.
 #[inline]
 #[cold]
-pub fn abort() -> ! {
-    crate::arch::abort()
+pub fn trap() -> ! {
+    crate::arch::trap()
 }

--- a/src/relocate.rs
+++ b/src/relocate.rs
@@ -27,8 +27,8 @@
 #![allow(clippy::cmp_null)]
 
 use crate::arch::{
-    abort, dynamic_table_addr, ehdr_addr, relocation_load, relocation_mprotect_readonly,
-    relocation_store,
+    dynamic_table_addr, ehdr_addr, relocation_load, relocation_mprotect_readonly, relocation_store,
+    trap,
 };
 #[cfg(not(feature = "nightly"))]
 use crate::ptr::addr;
@@ -55,14 +55,14 @@ const DT_RELR: usize = 36;
 #[cfg(debug_assertions)]
 const DT_RELRENT: usize = 37;
 
-// We have to override the debug_assert! family of macros to abort rather than
+// We have to override the debug_assert! family of macros to trap rather than
 // panic as panicking doesn't work this early on. See the docs of [relocate]
 // for more info.
 #[cfg(debug_assertions)]
 macro_rules! debug_assert_eq {
     ($l:expr, $r:expr) => {
         if !($l == $r) {
-            abort();
+            trap();
         }
     };
 }
@@ -232,9 +232,9 @@ pub(super) unsafe fn relocate(envp: *mut *mut u8) {
                 let reloc_value = addend.wrapping_add(offset);
                 relocation_store(reloc_addr, reloc_value);
             }
-            // Abort the process without panicking as panicking requires
+            // Trap the process without panicking as panicking requires
             // relocations to be performed first.
-            _ => abort(),
+            _ => trap(),
         }
     }
 
@@ -255,9 +255,9 @@ pub(super) unsafe fn relocate(envp: *mut *mut u8) {
                 let reloc_value = addend.wrapping_add(offset);
                 relocation_store(reloc_addr, reloc_value);
             }
-            // Abort the process without panicking as panicking requires
+            // Trap the process without panicking as panicking requires
             // relocations to be performed first.
-            _ => abort(),
+            _ => trap(),
         }
     }
 

--- a/src/signal/linux_raw.rs
+++ b/src/signal/linux_raw.rs
@@ -10,6 +10,9 @@ pub use rustix::runtime::Sigaction;
 /// A signal identifier for use with [`sigaction`].
 pub use rustix::runtime::Signal;
 
+/// A signal set for use with [`Sigaction`].
+pub use rustix::runtime::Sigset;
+
 /// A signal handler function for use with [`Sigaction`].
 pub use linux_raw_sys::general::__kernel_sighandler_t as Sighandler;
 

--- a/src/stubs.rs
+++ b/src/stubs.rs
@@ -17,9 +17,9 @@ unsafe extern "C" fn rust_eh_personality(
     8 // UnwindReasonCode::CONTINUE_UNWIND
 }
 
-// If requested, provide a version of "panic-handler-abort" ourselves.
-#[cfg(feature = "panic-handler-abort")]
+// If requested, provide a version of "panic-handler-trap" ourselves.
+#[cfg(feature = "panic-handler-trap")]
 #[panic_handler]
 fn panic(_info: &core::panic::PanicInfo<'_>) -> ! {
-    crate::arch::abort()
+    crate::arch::trap()
 }

--- a/test-crates/origin-start/Cargo.toml
+++ b/test-crates/origin-start/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 publish = false
 
 [dependencies]
-origin = { path = "../..", default-features = false, features = ["origin-start", "program-at-exit", "thread-at-exit", "signal", "eh-personality-continue", "panic-handler-abort", "nightly"] }
+origin = { path = "../..", default-features = false, features = ["origin-start", "program-at-exit", "thread-at-exit", "signal", "eh-personality-continue", "panic-handler-trap", "nightly"] }
 atomic-dbg = { version = "0.1.8", default-features = false }
 rustix-dlmalloc = { version = "0.1.0", features = ["global"] }
 rustix = { version = "0.38", default-features = false, features = ["thread"] }

--- a/test-crates/origin-start/Cargo.toml
+++ b/test-crates/origin-start/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 publish = false
 
 [dependencies]
-origin = { path = "../..", default-features = false, features = ["origin-start", "program-at-exit", "thread-at-exit", "eh-personality-continue", "panic-handler-abort", "nightly"] }
+origin = { path = "../..", default-features = false, features = ["origin-start", "program-at-exit", "thread-at-exit", "signal", "eh-personality-continue", "panic-handler-abort", "nightly"] }
 atomic-dbg = { version = "0.1.8", default-features = false }
 rustix-dlmalloc = { version = "0.1.0", features = ["global"] }
 rustix = { version = "0.38", default-features = false, features = ["thread"] }

--- a/test-crates/origin-start/src/bin/abort-via-raise.rs
+++ b/test-crates/origin-start/src/bin/abort-via-raise.rs
@@ -1,0 +1,20 @@
+//! Test terminating the current process with `Signal::Abort`.
+
+#![no_std]
+#![no_main]
+#![allow(unused_imports)]
+
+extern crate alloc;
+
+use origin::{program, signal};
+
+#[global_allocator]
+static GLOBAL_ALLOCATOR: rustix_dlmalloc::GlobalDlmalloc = rustix_dlmalloc::GlobalDlmalloc;
+
+#[no_mangle]
+unsafe fn origin_main(_argc: usize, _argv: *mut *mut u8, _envp: *mut *mut u8) -> i32 {
+    // Terminate the current process using `Signal::Abort`.
+    rustix::runtime::tkill(rustix::thread::gettid(), signal::Signal::Abort).ok();
+    // We shouldn't get here.
+    12
+}

--- a/test-crates/origin-start/src/bin/trap.rs
+++ b/test-crates/origin-start/src/bin/trap.rs
@@ -1,0 +1,17 @@
+//! Test `program::trap`.
+
+#![no_std]
+#![no_main]
+#![allow(unused_imports)]
+
+extern crate alloc;
+
+use origin::program;
+
+#[global_allocator]
+static GLOBAL_ALLOCATOR: rustix_dlmalloc::GlobalDlmalloc = rustix_dlmalloc::GlobalDlmalloc;
+
+#[no_mangle]
+unsafe fn origin_main(_argc: usize, _argv: *mut *mut u8, _envp: *mut *mut u8) -> i32 {
+    program::trap()
+}

--- a/tests/test_crates.rs
+++ b/tests/test_crates.rs
@@ -4,6 +4,8 @@
 // Most of the test crates only work with nightly.
 #![cfg(feature = "nightly")]
 
+use std::os::unix::process::ExitStatusExt;
+
 mod utils;
 
 fn test_crate(
@@ -121,5 +123,29 @@ fn test_main_thread_dtors_adding_dtors() {
         "",
         "",
         Some(0),
+    );
+}
+
+#[test]
+fn test_trap() {
+    let mut command = utils::run_test("test", "run", "origin-start", &["--bin=trap"], &[]);
+    assert_eq!(
+        command.output().unwrap().status.signal(),
+        Some(origin::signal::Signal::Ill as i32)
+    );
+}
+
+#[test]
+fn test_abort_via_raise() {
+    let mut command = utils::run_test(
+        "test",
+        "run",
+        "origin-start",
+        &["--bin=abort-via-raise"],
+        &[],
+    );
+    assert_eq!(
+        command.output().unwrap().status.signal(),
+        Some(origin::signal::Signal::Abort as i32)
     );
 }

--- a/tests/test_crates.rs
+++ b/tests/test_crates.rs
@@ -127,6 +127,7 @@ fn test_main_thread_dtors_adding_dtors() {
 }
 
 #[test]
+#[ignore] // TODO: This test isn't handled well by qemu.
 fn test_trap() {
     let mut command = utils::run_test("test", "run", "origin-start", &["--bin=trap"], &[]);
     assert_eq!(


### PR DESCRIPTION
Instead of providing an "abort" function, which might be confused with `libc::abort` which has subtly different behavior, provide a "trap" function, which just does one clear thing.