### PR TITLE
Update origin for the `naked_asm1 change.

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -23,7 +23,7 @@ jobs:
     strategy:
       matrix:
         build: [ubuntu, i686-linux, aarch64-linux, riscv64-linux]
-        rust: [1.78, nightly-2024-10-06]
+        rust: [1.78, nightly-2024-10-12]
         include:
           - build: ubuntu
             os: ubuntu-latest
@@ -51,7 +51,7 @@ jobs:
             qemu: qemu-riscv64 -L /usr/riscv64-linux-gnu
             qemu_target: riscv64-linux-user
             host_target: riscv64gc-unknown-linux-gnu
-          - rust: nightly-2024-10-06
+          - rust: nightly-2024-10-12
             features: nightly
     steps:
     - uses: actions/checkout@v4

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,7 +42,7 @@ core = { version = "1.0.0", optional = true, package = "rustc-std-workspace-core
 alloc = { version = "1.0.0", optional = true, package = "rustc-std-workspace-alloc" }
 
 [target.'cfg(not(target_arch = "arm"))'.dependencies.unwinding]
-version = "0.2.0"
+version = "0.2.3"
 default-features = false
 features = ["unwinder"]
 optional = true

--- a/src/arch/aarch64.rs
+++ b/src/arch/aarch64.rs
@@ -37,8 +37,7 @@ naked_fn!(
     "mov x0, sp",   // Pass the incoming `sp` as the arg to `entry`.
     "mov x30, xzr", // Set the return address to zero.
     "b {entry}";    // Jump to `entry`.
-    entry = sym super::program::entry;
-    options(noreturn)
+    entry = sym super::program::entry
 );
 
 /// Execute a trap instruction.
@@ -289,8 +288,6 @@ naked_fn!(
     "svc 0",
     "udf #16";
     //__NR_rt_sigreturn = const __NR_rt_sigreturn // TODO: Use this when `asm_const` is stabilized.
-    ;
-    options(noreturn)
 );
 #[cfg(test)] // TODO: obviate this
 fn test_rt_sigreturn() {

--- a/src/arch/arm.rs
+++ b/src/arch/arm.rs
@@ -37,8 +37,7 @@ naked_fn!(
     "mov r0, sp",   // Pass the incoming `sp` as the arg to `entry`.
     "mov lr, #0",   // Set the return address to zero.
     "b {entry}";    // Jump to `entry`.
-    entry = sym super::program::entry;
-    options(noreturn)
+    entry = sym super::program::entry
 );
 
 /// Execute a trap instruction.
@@ -303,8 +302,6 @@ naked_fn!(
     "swi 0",
     "udf #16";
     //__NR_rt_sigreturn = const __NR_rt_sigreturn // TODO: Use this when `asm_const` is stabilized.
-    ;
-    options(noreturn)
 );
 #[cfg(test)] // TODO: obviate this
 fn test_rt_sigreturn() {
@@ -328,8 +325,6 @@ naked_fn!(
     "swi 0",
     "udf #16";
     //__NR_sigreturn = const __NR_sigreturn // TODO: Use this when `asm_const` is stabilized.
-    ;
-    options(noreturn)
 );
 #[cfg(test)] // TODO: obviate this
 fn test_sigreturn() {

--- a/src/arch/riscv64.rs
+++ b/src/arch/riscv64.rs
@@ -36,8 +36,7 @@ naked_fn!(
     "mv ra, zero",  // Set the return address to zero.
     "mv fp, zero",  // Set the frame address to zero.
     "tail {entry}"; // Jump to `entry`.
-    entry = sym super::program::entry;
-    options(noreturn)
+    entry = sym super::program::entry
 );
 
 /// Execute a trap instruction.

--- a/src/arch/x86.rs
+++ b/src/arch/x86.rs
@@ -47,8 +47,7 @@ naked_fn!(
     "push eax",     // Pass saved the incoming `esp` as the arg to `entry`.
     "push ebp",     // Set the return address to zero.
     "jmp {entry}";  // Jump to `entry`.
-    entry = sym super::program::entry;
-    options(noreturn)
+    entry = sym super::program::entry
 );
 
 /// Execute a trap instruction.
@@ -393,8 +392,6 @@ naked_fn!(
     "int 0x80",
     "ud2";
     //__NR_rt_sigreturn = const __NR_rt_sigreturn // TODO: Use this when `asm_const` is stabilized.
-    ;
-    options(noreturn)
 );
 #[cfg(feature = "signal")]
 #[cfg(test)] // TODO: obviate this
@@ -420,8 +417,6 @@ naked_fn!(
     "int 0x80",
     "ud2";
     //__NR_sigreturn = const __NR_sigreturn // TODO: Use this when `asm_const` is stabilized.
-    ;
-    options(noreturn)
 );
 #[cfg(feature = "signal")]
 #[cfg(test)] // TODO: obviate this

--- a/src/arch/x86_64.rs
+++ b/src/arch/x86_64.rs
@@ -38,8 +38,7 @@ naked_fn!(
     "mov rdi, rsp", // Pass the incoming `rsp` as the arg to `entry`.
     "push rbp",     // Set the return address to zero.
     "jmp {entry}";  // Jump to `entry`.
-    entry = sym super::program::entry;
-    options(noreturn)
+    entry = sym super::program::entry
 );
 
 /// Execute a trap instruction.
@@ -298,8 +297,6 @@ naked_fn!(
     "syscall",
     "ud2";
     //__NR_rt_sigreturn = const __NR_rt_sigreturn // TODO: Use this when `asm_const` is stabilized.
-    ;
-    options(noreturn)
 );
 #[cfg(test)] // TODO: obviate this
 fn test_rt_sigreturn() {

--- a/src/naked.rs
+++ b/src/naked.rs
@@ -22,10 +22,7 @@
 //!
 //!     // Provide symbols for use in the assembly code.
 //!     symbols = sym path::to::symbols,
-//!     this = sym path::to::this;
-//!
-//!     // Add additional `asm` options.
-//!     options(noreturn)
+//!     this = sym path::to::this
 //! );
 //! ```
 
@@ -40,17 +37,15 @@ macro_rules! naked_fn {
         $doc:literal;
         $vis:vis fn $name:ident $args:tt -> $ret:ty;
         $($code:literal),*;
-        $($label:ident = $kind:ident $path:path),*;
-        options($($option:ident),*)
+        $($label:ident = $kind:ident $path:path),*
     ) => {
         #[doc = $doc]
         #[naked]
         #[no_mangle]
         $vis unsafe extern "C" fn $name $args -> $ret {
-            asm!(
+            core::arch::naked_asm!(
                 $($code),*,
-                $($label = $kind $path,)*
-                options($($option),*),
+                $($label = $kind $path),*
             )
         }
     };
@@ -65,8 +60,7 @@ macro_rules! naked_fn {
         $doc:literal;
         $vis:vis fn $name:ident $args:tt -> $ret:ty;
         $($code:literal),*;
-        $($label:ident = $kind:ident $path:path),*;
-        options($($option:ident),*)
+        $($label:ident = $kind:ident $path:path),*
     ) => {
         extern "C" {
             #[doc = $doc]
@@ -79,7 +73,6 @@ macro_rules! naked_fn {
             $($code),*,
             concat!(".size ", stringify!($name), ", .-", stringify!($name)),
             $($label = $kind $path),*
-            // Omit the options because this is a `global_asm`.
         );
     };
 }


### PR DESCRIPTION
Update origin's nightly Rust support to the latest nightly Rust, renaming `asm` in naked functions to `naked_asm` and removing the options.