### PR TITLE
fix: Ensure `mod unwind_unimplemented` works without `nightly` feature enabled

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -68,7 +68,7 @@ default = ["std", "log", "libc", "errno", "signal", "init-fini-arrays", "program
 # If you're using nightly Rust, enable this feature to let origin use
 # nightly-only features, which include proper support for unwinding (if
 # enabled), better safety checks, and better optimizations.
-nightly = ["dep:unwinding"]
+nightly = ["unwinding"]
 
 # Enable optimizations that reduce code size (at the cost of performance).
 optimize_for_size = []

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -68,7 +68,7 @@ default = ["std", "log", "libc", "errno", "signal", "init-fini-arrays", "program
 # If you're using nightly Rust, enable this feature to let origin use
 # nightly-only features, which include proper support for unwinding (if
 # enabled), better safety checks, and better optimizations.
-nightly = ["unwinding"]
+nightly = ["dep:unwinding"]
 
 # Enable optimizations that reduce code size (at the cost of performance).
 optimize_for_size = []

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -37,8 +37,12 @@ pub(crate) mod naked;
 #[cfg(all(feature = "unwinding", not(target_arch = "arm")))]
 #[allow(unused_extern_crates)]
 extern crate unwinding;
-#[cfg(all(feature = "unwinding", target_arch = "arm"))]
+#[cfg(any(not(feature = "unwinding"), target_arch = "arm"))]
 mod unwind_unimplemented;
+// If we don't have "unwinding", provide stub functions for unwinding and
+// panicking.
+#[cfg(not(feature = "unwinding"))]
+mod stubs;
 
 #[cfg_attr(target_arch = "aarch64", path = "arch/aarch64.rs")]
 #[cfg_attr(target_arch = "x86_64", path = "arch/x86_64.rs")]
@@ -65,11 +69,6 @@ pub mod signal;
 #[cfg_attr(feature = "take-charge", path = "thread/linux_raw.rs")]
 #[cfg_attr(not(feature = "take-charge"), path = "thread/libc.rs")]
 pub mod thread;
-
-// If we don't have "unwinding", provide stub functions for unwinding and
-// panicking.
-#[cfg(not(feature = "unwinding"))]
-mod stubs;
 
 // Include definitions of `memcpy` and other functions called from LLVM
 // Codegen. Normally, these would be defined by the platform libc, however with


### PR DESCRIPTION
**TL;DR:** The PR now only reverts a recent change, so that `origin` will have `mod unwind_unimplemented` when the `nightly` / `unwinding` feature is not enabled. [Details here](https://github.com/sunfishcode/origin/pull/150/files#r1808146671).

Originally this PR was intended to fix building `unwinding` with `nightly` feature for `panic = "abort"` but I was mistaken as the update below notes. That build issue will be resolved with release of `unwinding` after `0.2.3` via: https://github.com/nbdd0121/unwinding/pull/40

---

<details>
<summary>Original PR message (with update)</summary>

This restores the [Eyra `hello-world-small`](https://github.com/sunfishcode/eyra/tree/v0.19.0/example-crates/hello-world-small) crate [example to build with `panic = "abort"`](https://github.com/sunfishcode/eyra/pull/54#issuecomment-2425108717).

References:
- https://github.com/sunfishcode/origin/pull/149/files#r1808139103
- https://github.com/nbdd0121/unwinding/issues/39#issuecomment-2425645660

---

~~This PR isn't quite ready to merge, when built there is many warnings now emitted about the `feature = "unwinding"` no longer being valid as it is no longer created implicitly from the `nightly` feature requirements.~~

**UPDATE:** I was mistaken about `nightly = ["dep:unwinding"]` vs `nightly = ["unwinding"]`. Apart from the difference in implicit feature being dropped, the difference did not actually affect the `cfg` condition on the `unwinding` dependency itself, or at least I cannot reproduce such.

I did notice that `panic = "abort"` in `Cargo.toml` has no affect on the dependency condition (_only `-C panic=abort` does_):

```toml
# This is only prevented by `-C panic=abort`, not by equivalent `Cargo.toml` setting
[target.'cfg(panic = "unwind")'.dependencies.some-crate]
version = "0.1.0"

[profile.release]
panic = "abort"
```

```rust
// Either approach for setting abort works here though
fn main() {
    #[cfg(panic = "unwind")]
    println!("unwind");

    #[cfg(panic = "abort")]
    println!("abort");
}
```

```bash
RUSTFLAGS='-C panic=abort' cargo run --release
```

</details>
