### PR TITLE
Update to unwinding 0.2.4.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,8 +43,8 @@ alloc = { version = "1.0.0", optional = true, package = "rustc-std-workspace-all
 
 # Use the unwinding crate if support for unwinding is needed. This depends on
 # nightly Rust. And it's not supported on ARM yet.
-[target.'cfg(all(panic = "unwind", not(target_arch = "arm")))'.dependencies.unwinding]
-version = "0.2.3"
+[target.'cfg(not(target_arch = "arm"))'.dependencies.unwinding]
+version = "0.2.4"
 default-features = false
 features = ["unwinder"]
 optional = true

--- a/example-crates/origin-start-panic-abort/README.md
+++ b/example-crates/origin-start-panic-abort/README.md
@@ -1,3 +1,4 @@
-Like the [origin-start example], but uses panic=abort in Cargo.toml.
+Like the [origin-start example], but uses panic=abort in Cargo.toml instead of
+enabling origin's "unwinding" feature.
 
 [origin-start example]: https://github.com/sunfishcode/origin/blob/main/example-crates/origin-start/README.md


### PR DESCRIPTION
Remove the `cfg(panic = "unwind")` in Cargo.toml.