### PR TITLE
Update to the latest Rust.

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -23,7 +23,7 @@ jobs:
     strategy:
       matrix:
         build: [ubuntu, i686-linux, aarch64-linux, riscv64-linux]
-        rust: [1.78, nightly-2024-10-12]
+        rust: [1.78, nightly-2025-01-02]
         include:
           - build: ubuntu
             os: ubuntu-latest
@@ -51,7 +51,7 @@ jobs:
             qemu: qemu-riscv64 -L /usr/riscv64-linux-gnu
             qemu_target: riscv64-linux-user
             host_target: riscv64gc-unknown-linux-gnu
-          - rust: nightly-2024-10-12
+          - rust: nightly-2025-01-02
             features: nightly
     steps:
     - uses: actions/checkout@v4

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,7 +44,7 @@ alloc = { version = "1.0.0", optional = true, package = "rustc-std-workspace-all
 # Use the unwinding crate if support for unwinding is needed. This depends on
 # nightly Rust. And it's not supported on ARM yet.
 [target.'cfg(not(target_arch = "arm"))'.dependencies.unwinding]
-version = "0.2.4"
+version = "0.2.5"
 default-features = false
 features = ["unwinder"]
 optional = true

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,2 +1,0 @@
-[toolchain]
-components = ["rustc", "cargo", "rust-std", "rust-src", "rustfmt"]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,13 +13,8 @@
 )]
 // Allow our polyfills to polyfill nightly features.
 #![cfg_attr(not(feature = "nightly"), allow(unstable_name_collisions))]
-// On nightly, enable strict provenance.
-#![cfg_attr(feature = "nightly", feature(strict_provenance))]
-#![cfg_attr(feature = "nightly", feature(exposed_provenance))]
-#![cfg_attr(
-    feature = "nightly",
-    deny(fuzzy_provenance_casts, lossy_provenance_casts)
-)]
+// Allow `Polyfill` imports to be unused for now.
+#![cfg_attr(not(feature = "nightly"), allow(unused_imports))]
 
 #[cfg(all(feature = "alloc", not(feature = "rustc-dep-of-std")))]
 extern crate alloc;

--- a/src/ptr.rs
+++ b/src/ptr.rs
@@ -77,7 +77,7 @@ impl<T> Polyfill<T> for *const T {
 
     #[inline]
     fn map_addr(self, f: impl FnOnce(usize) -> usize) -> *mut T {
-        self.with_addr(f(self.addr()))
+        self.with_addr(f(self.addr())).cast_mut()
     }
 
     #[inline]

--- a/test-crates/origin-start/src/bin/tls.rs
+++ b/test-crates/origin-start/src/bin/tls.rs
@@ -4,7 +4,6 @@
 #![no_std]
 #![no_main]
 #![feature(thread_local)]
-#![feature(strict_provenance)]
 
 extern crate alloc;
 


### PR DESCRIPTION
Strict provenance APIs are now available by default on nightly. And unwinding 0.2.5 fixes compatibility with the latest nightly
