### PR TITLE
Rename `exit_immediately` to `immediate_exit`.

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -75,7 +75,7 @@ jobs:
       run: |
         set -ex
         sudo apt-get update
-        sudo apt-get install -y ${{ matrix.gcc_package }} ninja-build
+        sudo apt-get install -y ${{ matrix.gcc_package }} ninja-build libglib2.0-dev
         upcase=$(echo ${{ matrix.host_target }} | awk '{ print toupper($0) }' | sed 's/-/_/g')
         echo CARGO_TARGET_${upcase}_LINKER=${{ matrix.gcc }} >> $GITHUB_ENV
         echo CC_${{ matrix.target }}=${{ matrix.gcc }} >> $GITHUB_ENV

--- a/example-crates/tiny-hello/src/main.rs
+++ b/example-crates/tiny-hello/src/main.rs
@@ -16,5 +16,5 @@ unsafe fn origin_main(_argc: usize, _argv: *mut *mut u8, _envp: *mut *mut u8) ->
             Err(_) => origin::program::trap(),
         }
     }
-    origin::program::exit_immediately(0);
+    origin::program::immediate_exit(0);
 }

--- a/src/program/libc.rs
+++ b/src/program/libc.rs
@@ -71,7 +71,7 @@ pub fn exit(status: c_int) -> ! {
 /// Exit the program without calling functions registered with [`at_exit`] or
 /// with the `.fini_array` section.
 #[inline]
-pub fn exit_immediately(status: c_int) -> ! {
+pub fn immediate_exit(status: c_int) -> ! {
     unsafe {
         // Call `libc` to exit the program.
         libc::_exit(status)

--- a/src/program/linux_raw.rs
+++ b/src/program/linux_raw.rs
@@ -325,14 +325,14 @@ pub fn exit(status: c_int) -> ! {
         }
     }
 
-    // Call `exit_immediately` to exit the program.
-    exit_immediately(status)
+    // Call `immediate_exit` to exit the program.
+    immediate_exit(status)
 }
 
 /// Exit the program without calling functions registered with [`at_exit`] or
 /// with the `.fini_array` section.
 #[inline]
-pub fn exit_immediately(status: c_int) -> ! {
+pub fn immediate_exit(status: c_int) -> ! {
     #[cfg(feature = "log")]
     log::trace!("Program exiting with status `{:?}`", status);
 


### PR DESCRIPTION
Aligning with the suggestion [here], which in turn is aligning with [`quick_exit`], rename `exit_immediately` to `immediate_exit`.

[here]: https://github.com/bytecodealliance/rustix/pull/1133#discussion_r1731975830
[`quick_exit`]: https://en.cppreference.com/w/c/program/quick_exit