### PR TITLE
Fix MIPS __start linker error with default relocation model

### DIFF
--- a/src/arch/mips32.rs
+++ b/src/arch/mips32.rs
@@ -50,8 +50,9 @@ pub(super) unsafe extern "C" fn __start() -> ! {
         "and $sp, $sp, -8",     // Align stack to 8 bytes.
         "subu $sp, $sp, 16",    // Reserve 16 bytes for O32 ABI argument save area.
         "move $ra, $zero",      // Set the return address to zero.
-        "la $t9, {entry}",      // Load entry address into $t9.
-        "jr $t9",               // Jump to `entry` via $t9 (required for PIC).
+        "lui $t9, %hi({entry})",        // Load entry address into $t9.
+        "addiu $t9, $t9, %lo({entry})", //
+        "jr $t9",               // Jump to `entry` via $t9 (PIC convention).
         "nop",                  // Branch delay slot.
         ".set reorder",
         entry = sym super::program::entry


### PR DESCRIPTION
Embarrassing follow-up to #170 - I introduced a bug in the MIPS startup code.

The `la $t9, {entry}` instruction in `__start` generates a CALL16 relocation when compiled with PIC (which is the default relocation model for `mipsel-unknown-linux-gnu`). CALL16 requires the target to be a global symbol, but `entry` is `pub(super)` so the linker rejects it:

```
mipsel-linux-gnu-ld: CALL16 reloc at 0x18 not against global symbol
```

I missed this because my test setup happened to use `-C relocation-model=static`, which avoids PIC entirely. So it linked fine on my end and I never saw the issue. Anyone using the default relocation model would hit this on their first MIPS build.

The fix is to use `lui`/`addiu` instead of `la`. These generate HI16/LO16 relocations which work with local symbols. Still loads the address into `$t9` for PIC convention, just without going through the GOT.

Tested by building a real application (kv) for `mipsel-unknown-linux-gnu` *without* the relocation-model workaround. Links and runs correctly under QEMU.

Sorry about the mess.